### PR TITLE
fix: improve debug string

### DIFF
--- a/pytest-embedded-idf/pytest_embedded_idf/app.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/app.py
@@ -154,13 +154,13 @@ class IdfApp(App):
         for fn in os.listdir(self.binary_path):
             if os.path.splitext(fn)[-1] == '.elf':
                 return os.path.realpath(os.path.join(self.binary_path, fn))
-        raise ValueError('Elf file not found')
+        raise ValueError(f'Elf file under {self.binary_path} not found')
 
     def _get_bin_file(self) -> str:
         for fn in os.listdir(self.binary_path):
             if os.path.splitext(fn)[-1] == '.bin':
                 return os.path.realpath(os.path.join(self.binary_path, fn))
-        raise ValueError('Bin file not found')
+        raise ValueError(f'Bin file under {self.binary_path} not found')
 
     def _parse_flash_args(
         self,

--- a/pytest-embedded/tests/test_base.py
+++ b/pytest-embedded/tests/test_base.py
@@ -279,7 +279,7 @@ def test_expect(testdir):
             with pytest.raises(pexpect.TIMEOUT) as e:
                 dut.expect(pattern_list, expect_all=True, timeout=1)
 
-            assert e.value.value.startswith('Not found "[\'foobar\']" with arguments {\'timeout\': 1}\n')
+            assert e.value.value.startswith('Not found "[\'foobar\']"')
     """)
 
     result = testdir.runpytest()


### PR DESCRIPTION
sometimes the current buffer would be too long to track. use textwrap
to make it readable.