### PR TITLE
Fix esptool imports (RDT-222)

### DIFF
--- a/pytest-embedded-idf/pytest_embedded_idf/app.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/app.py
@@ -214,7 +214,13 @@ class IdfApp(App):
         Returns:
             sha256 appended to app
         """
-        from esptool import LoadFirmwareImage, hexify
+        from pytest_embedded_serial_esp.serial import EspSerial, EsptoolVersion
+
+        if EspSerial.ESPTOOL_VERSION == EsptoolVersion.V3:
+            from esptool import LoadFirmwareImage, hexify
+        else:
+            from esptool.bin_image import LoadFirmwareImage
+            from esptool.util import hexify
 
         image = LoadFirmwareImage(self.target, filepath)
         if image.append_digest:


### PR DESCRIPTION
This MR fixes esptool imports.

https://github.com/espressif/pytest-embedded/pull/77#discussion_r834197044