### PR TITLE
Add erase-flash option to erase the flash before programming. (RDT-234)

### DIFF
--- a/pytest-embedded-arduino/pytest_embedded_arduino/serial.py
+++ b/pytest-embedded-arduino/pytest_embedded_arduino/serial.py
@@ -25,10 +25,11 @@ class ArduinoSerial(EspSerial):
         baud: int = EspSerial.DEFAULT_BAUDRATE,
         target: Optional[str] = None,
         skip_autoflash: bool = False,
+        erase_flash: bool = False,
         **kwargs,
     ) -> None:
         self.app = app
-        super().__init__(pexpect_proc, target or self.app.target, port, baud, skip_autoflash, **kwargs)
+        super().__init__(pexpect_proc, target or self.app.target, port, baud, skip_autoflash, erase_flash, **kwargs)
 
     def _start(self):
         if self.skip_autoflash:
@@ -67,6 +68,9 @@ class ArduinoSerial(EspSerial):
         if self.ESPTOOL_VERSION == EsptoolVersion.V4:
             default_kwargs['force'] = False
             default_kwargs['chip'] = self.app.target
+
+        if self.erase_flash:
+            default_kwargs['erase_all'] = True
 
         default_kwargs.update(self.app.flash_settings)
         flash_args = FlashArgs(default_kwargs)

--- a/pytest-embedded-idf/pytest_embedded_idf/serial.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/serial.py
@@ -29,6 +29,7 @@ class IdfSerial(EspSerial):
         port: Optional[str] = None,
         baud: int = EspSerial.DEFAULT_BAUDRATE,
         skip_autoflash: bool = False,
+        erase_flash: bool = False,
         port_app_cache: Dict[str, str] = None,
         confirm_target_elf_sha256: bool = False,
         erase_nvs: bool = False,
@@ -45,7 +46,7 @@ class IdfSerial(EspSerial):
         if target and self.app.target and self.app.target != target:
             raise ValueError(f'Targets do not match. App target: {self.app.target}, Cmd target: {target}.')
 
-        super().__init__(pexpect_proc, target or app.target, port, baud, skip_autoflash, **kwargs)
+        super().__init__(pexpect_proc, target or app.target, port, baud, skip_autoflash, erase_flash, **kwargs)
 
     def _post_init(self):
         if self.esp.serial_port in self._port_app_cache:
@@ -128,6 +129,9 @@ class IdfSerial(EspSerial):
 
         if self.ESPTOOL_VERSION == EsptoolVersion.V4:
             default_kwargs['force'] = False
+
+        if self.erase_flash:
+            default_kwargs['erase_all'] = True
 
         default_kwargs.update(self.app.flash_settings)
         default_kwargs.update(self.app.flash_args.get('extra_esptool_args', {}))

--- a/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
+++ b/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
@@ -42,6 +42,7 @@ class EspSerial(Serial):
         port: Optional[str] = None,
         baud: int = DEFAULT_BAUDRATE,
         skip_autoflash: bool = False,
+        erase_flash: bool = False,
         port_target_cache: Dict[str, str] = None,
         **kwargs,
     ) -> None:
@@ -87,6 +88,7 @@ class EspSerial(Serial):
         self.target = target
 
         self.skip_autoflash = skip_autoflash
+        self.erase_flash = erase_flash
         super().__init__(pexpect_proc, port=self.esp._port, **kwargs)
 
     def _post_init(self):

--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -115,6 +115,11 @@ def pytest_addoption(parser):
         '--skip-autoflash',
         help='y/yes/true for True and n/no/false for False. Set to True to disable auto flash. (Default: False)',
     )
+    esp_group.addoption(
+        '--erase-flash',
+        help='y/yes/true for True and n/no/false for False. Set to True to erase flash before programming. '
+        '(Default: False)',
+    )
 
     idf_group = parser.getgroup('embedded-idf')
     idf_group.addoption(
@@ -566,6 +571,13 @@ def skip_autoflash(request: FixtureRequest) -> Optional[bool]:
     return _request_param_or_config_option_or_default(request, 'skip_autoflash', None)
 
 
+@pytest.fixture
+@multi_dut_argument
+def erase_flash(request: FixtureRequest) -> Optional[bool]:
+    """Enable parametrization for the same cli option"""
+    return _request_param_or_config_option_or_default(request, 'erase_flash', None)
+
+
 #######
 # idf #
 #######
@@ -704,6 +716,7 @@ def _fixture_classes_and_options(
     target,
     baud,
     skip_autoflash,
+    erase_flash,
     part_tool,
     confirm_target_elf_sha256,
     erase_nvs,
@@ -792,6 +805,7 @@ def _fixture_classes_and_options(
                     'port': os.getenv('ESPPORT') or port,
                     'baud': int(os.getenv('ESPBAUD') or baud or EspSerial.DEFAULT_BAUDRATE),
                     'skip_autoflash': skip_autoflash,
+                    'erase_flash': erase_flash,
                 }
                 if 'idf' in _services:
                     from pytest_embedded_idf.serial import IdfSerial


### PR DESCRIPTION
Add an option to erase the flash before programming. And example that needs this is: https://github.com/espressif/arduino-esp32/pull/6916
Tested with the Arduino example by adding:

```diff
diff --git a/examples/arduino/hello_world/test_hello_world.py b/examples/arduino/hello_world/test_hello_world.py
index 0e7cea8..03f7346 100644
--- a/examples/arduino/hello_world/test_hello_world.py
+++ b/examples/arduino/hello_world/test_hello_world.py
@@ -1,2 +1,9 @@
+import pytest
+
+@pytest.mark.parametrize(
+    'erase_flash',
+    ['True'],
+    indirect=True,
+)
 def test_hello_arduino(dut):
     dut.expect('Hello Arduino!')
```

IDF service added a similar function bu I am not sure how that one is used.