### PR TITLE
fix cli option "--erase-flash" conflict with function `erase_flash()`

### DIFF
--- a/pytest-embedded-arduino/pytest_embedded_arduino/serial.py
+++ b/pytest-embedded-arduino/pytest_embedded_arduino/serial.py
@@ -25,11 +25,11 @@ class ArduinoSerial(EspSerial):
         baud: int = EspSerial.DEFAULT_BAUDRATE,
         target: Optional[str] = None,
         skip_autoflash: bool = False,
-        erase_flash: bool = False,
+        erase_all: bool = False,
         **kwargs,
     ) -> None:
         self.app = app
-        super().__init__(pexpect_proc, target or self.app.target, port, baud, skip_autoflash, erase_flash, **kwargs)
+        super().__init__(pexpect_proc, target or self.app.target, port, baud, skip_autoflash, erase_all, **kwargs)
 
     def _start(self):
         if self.skip_autoflash:
@@ -69,7 +69,7 @@ class ArduinoSerial(EspSerial):
             default_kwargs['force'] = False
             default_kwargs['chip'] = self.app.target
 
-        if self.erase_flash:
+        if self.erase_all:
             default_kwargs['erase_all'] = True
 
         default_kwargs.update(self.app.flash_settings)

--- a/pytest-embedded-idf/pytest_embedded_idf/serial.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/serial.py
@@ -29,7 +29,7 @@ class IdfSerial(EspSerial):
         port: Optional[str] = None,
         baud: int = EspSerial.DEFAULT_BAUDRATE,
         skip_autoflash: bool = False,
-        erase_flash: bool = False,
+        erase_all: bool = False,
         port_app_cache: Dict[str, str] = None,
         confirm_target_elf_sha256: bool = False,
         erase_nvs: bool = False,
@@ -46,7 +46,7 @@ class IdfSerial(EspSerial):
         if target and self.app.target and self.app.target != target:
             raise ValueError(f'Targets do not match. App target: {self.app.target}, Cmd target: {target}.')
 
-        super().__init__(pexpect_proc, target or app.target, port, baud, skip_autoflash, erase_flash, **kwargs)
+        super().__init__(pexpect_proc, target or app.target, port, baud, skip_autoflash, erase_all, **kwargs)
 
     def _post_init(self):
         if self.esp.serial_port in self._port_app_cache:
@@ -130,7 +130,7 @@ class IdfSerial(EspSerial):
         if self.ESPTOOL_VERSION == EsptoolVersion.V4:
             default_kwargs['force'] = False
 
-        if self.erase_flash:
+        if self.erase_all:
             default_kwargs['erase_all'] = True
 
         default_kwargs.update(self.app.flash_settings)

--- a/pytest-embedded-idf/tests/test_idf.py
+++ b/pytest-embedded-idf/tests/test_idf.py
@@ -304,3 +304,41 @@ def test_no_elf_file(testdir):
     )
 
     result.assert_outcomes(passed=1)
+
+
+def test_erase_all(testdir):
+    testdir.makepyfile(r"""
+        def test_detect_port(dut):
+            dut.expect(r'Chip erase completed successfully in [\d.]+s', timeout=5)
+            dut.expect('Hash of data verified.', timeout=5)
+            dut.expect_exact('Hello world!', timeout=5)
+    """)
+
+    result = testdir.runpytest(
+        '-s',
+        '--embedded-services', 'esp,idf',
+        '--app-path', f'{os.path.join(testdir.tmpdir, "hello_world_esp32")}',
+        '--target', 'esp32',
+        '--erase-all', 'y',
+    )
+
+    result.assert_outcomes(passed=1)
+
+
+def test_erase_flash(testdir):
+    testdir.makepyfile(r"""
+        def test_detect_port(dut):
+            dut.serial.erase_flash()
+            dut.serial.flash()
+            dut.expect('Hash of data verified.', timeout=5)
+            dut.expect_exact('Hello world!', timeout=5)
+    """)
+
+    result = testdir.runpytest(
+        '-s',
+        '--embedded-services', 'esp,idf',
+        '--app-path', f'{os.path.join(testdir.tmpdir, "hello_world_esp32")}',
+        '--target', 'esp32',
+    )
+
+    result.assert_outcomes(passed=1)

--- a/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
+++ b/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
@@ -42,7 +42,7 @@ class EspSerial(Serial):
         port: Optional[str] = None,
         baud: int = DEFAULT_BAUDRATE,
         skip_autoflash: bool = False,
-        erase_flash: bool = False,
+        erase_all: bool = False,
         port_target_cache: Dict[str, str] = None,
         **kwargs,
     ) -> None:
@@ -88,7 +88,7 @@ class EspSerial(Serial):
         self.target = target
 
         self.skip_autoflash = skip_autoflash
-        self.erase_flash = erase_flash
+        self.erase_all = erase_all
         super().__init__(pexpect_proc, port=self.esp._port, **kwargs)
 
     def _post_init(self):

--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -116,8 +116,8 @@ def pytest_addoption(parser):
         help='y/yes/true for True and n/no/false for False. Set to True to disable auto flash. (Default: False)',
     )
     esp_group.addoption(
-        '--erase-flash',
-        help='y/yes/true for True and n/no/false for False. Set to True to erase flash before programming. '
+        '--erase-all',
+        help='y/yes/true for True and n/no/false for False. Set to True to erase all flash before programming. '
         '(Default: False)',
     )
 
@@ -578,9 +578,9 @@ def skip_autoflash(request: FixtureRequest) -> Optional[bool]:
 
 @pytest.fixture
 @multi_dut_argument
-def erase_flash(request: FixtureRequest) -> Optional[bool]:
+def erase_all(request: FixtureRequest) -> Optional[bool]:
     """Enable parametrization for the same cli option"""
-    return _request_param_or_config_option_or_default(request, 'erase_flash', None)
+    return _request_param_or_config_option_or_default(request, 'erase_all', None)
 
 
 #######
@@ -721,7 +721,7 @@ def _fixture_classes_and_options(
     target,
     baud,
     skip_autoflash,
-    erase_flash,
+    erase_all,
     part_tool,
     confirm_target_elf_sha256,
     erase_nvs,
@@ -810,7 +810,7 @@ def _fixture_classes_and_options(
                     'port': os.getenv('ESPPORT') or port,
                     'baud': int(os.getenv('ESPBAUD') or baud or EspSerial.DEFAULT_BAUDRATE),
                     'skip_autoflash': skip_autoflash,
-                    'erase_flash': erase_flash,
+                    'erase_all': erase_all,
                 }
                 if 'idf' in _services:
                     from pytest_embedded_idf.serial import IdfSerial


### PR DESCRIPTION
fix regression from https://github.com/espressif/pytest-embedded/pull/98