### PR TITLE
only hook on dut of type pytest_embedded.dut.Dut

### DIFF
--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -1149,7 +1149,7 @@ class PytestEmbedded:
     def pytest_runtest_call(self, item: Function):
         # raise dut failed cases
         if 'dut' in item.funcargs:
-            duts = to_list(item.funcargs['dut'])
+            duts = [dut for dut in to_list(item.funcargs['dut']) if isinstance(dut, Dut)]
             self._raise_dut_failed_cases_if_exists(duts)  # type: ignore
 
     @pytest.hookimpl(trylast=True)  # combine all possible junit reports should be the last step


### PR DESCRIPTION
pytest docs say that fixtures can be overridden: 

https://docs.pytest.org/en/latest/how-to/fixtures.html?highlight=override#override-a-fixture-on-a-test-module-level

When I override the `dut` fixture in a module, it still gets caught by this `pytest_embedded` hook.

This change explicitly checks that the dut is of type `pytest_embedded.dut.Dut`