### PR TITLE
docs: use readthedocs theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: pytest-embedded
 
 theme:
-  name: "material"
+  name: "readthedocs"
   palette:
     - scheme: default
       toggle:


### PR DESCRIPTION
related #127 

sphinx theme is highly binded to sphinx project. can't use that theme directly.

After changing the theme from `material` to `readthedocs` the layout turn out to be:

![image](https://user-images.githubusercontent.com/23117153/187865092-bdbf94b2-c592-4479-b0e4-e0e6cec69d02.png)
