### PR TITLE
fix(serial): use thread for serial

### DIFF
--- a/pytest-embedded-idf/pytest_embedded_idf/dut.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/dut.py
@@ -219,7 +219,7 @@ class IdfDut(SerialDut):
         else:
             raise ValueError(f'Invalid coredump format. Use _parse_b64_coredump for UART')
 
-        with self.serial.disable_redirect_serial():
+        with self.serial.disable_redirect_thread():
             coredump = CoreDump(
                 chip=self.target,
                 core_format=core_format,

--- a/pytest-embedded-serial/pytest_embedded_serial/dut.py
+++ b/pytest-embedded-serial/pytest_embedded_serial/dut.py
@@ -41,7 +41,7 @@ class SerialDut(Dut):
             self.setup_jtag()
 
     def write(self, data: AnyStr) -> None:
-        self.serial.proc.write(to_bytes(data, '\n'))  # noqa
+        self.serial.proc.write(to_bytes(data, '\n'))
 
     def setup_jtag(self):
         self.gdb.write(f'target extended-remote :{self.openocd.gdb_port}')

--- a/pytest-embedded-serial/pytest_embedded_serial/serial.py
+++ b/pytest-embedded-serial/pytest_embedded_serial/serial.py
@@ -1,9 +1,9 @@
 import contextlib
 import copy
-import inspect
 import logging
 import multiprocessing
 import queue
+import threading
 import time
 from typing import Dict, Optional
 
@@ -20,7 +20,6 @@ class Serial:
     Attributes:
         port (str): port address
         baud (int): baud rate
-        port_config (dict[str, Any]): port configs
         proc (pyserial.Serial): process created by `serial.serial_for_url()`
 
     Warning:
@@ -54,54 +53,58 @@ class Serial:
     ):
         self._q = msg_queue
         self._meta = meta
+        self._redirect_thread: _SerialRedirectThread = None  # type: ignore
 
-        self.port = port
         self.baud = baud
 
-        if port is None and not port_location:
-            raise ValueError('Please specify port or provide the port location')
-        if port_location:
-            for port in list_ports.comports():
-                if port.device in self.occupied_ports:
-                    continue
-                if port.location == port_location:
-                    if self.port and port.device != self.port:
-                        raise ValueError(
-                            f'The specified location {port_location} binds with port {port.device}, not {self.port}'
-                        )
+        if isinstance(port, pyserial.Serial):
+            self.proc = port
+            self.proc.timeout = self.DEFAULT_PORT_CONFIG['timeout']  # set read timeout
+            self.port = self.proc.port
+        else:
+            # Need to detect or create instance
+            if port_location:
+                for _port in list_ports.comports():
+                    if _port.device in self.occupied_ports:
+                        continue
+                    if _port.location == port_location:
+                        if port and _port.device != port:
+                            raise ValueError(
+                                f'The specified location {port_location} binds with port {_port.device}, not {port}'
+                            )
 
-                    self.port = port.device
-                    break
+                        self.port = _port.device
+                        break
+                else:
+                    raise ValueError(f'The specified location {port_location} cannot be found.')
+            elif port:
+                self.port = port
             else:
-                raise ValueError(f'The specified location {port_location} cannot be found.')
+                raise ValueError('Please specify port or provide the port location')
 
-        if not isinstance(self.port, str):
-            raise ValueError('`port` must be str, the real `pyserial` object must be created inside `self._forward_io`')
-
-        self.port_config = copy.deepcopy(self.DEFAULT_PORT_CONFIG)
-        self.port_config['baudrate'] = baud
-        self.port_config.update(**kwargs)
-
-        self.proc: _SerialRedirectProcess = None  # type: ignore
+            self.port = port
+            port_config = copy.deepcopy(self.DEFAULT_PORT_CONFIG)
+            port_config['baudrate'] = baud
+            port_config.update(**kwargs)
+            self.proc = pyserial.serial_for_url(self.port, **port_config)
 
         self._post_init()
         self._start()
         self._finalize_init()
 
-        self.start_redirect_process()
+        self.start_redirect_thread()
 
-    def start_redirect_process(self):
-        if self.proc and self.proc.is_alive():
+    def start_redirect_thread(self) -> None:
+        if self._redirect_thread and self._redirect_thread.is_alive():
             return
 
-        self.proc = _SerialRedirectProcess(self._q, self.port, self.port_config)
-        self.proc.start()
+        self._redirect_thread = _SerialRedirectThread(self._q, self.proc)
+        self._redirect_thread.start()
 
-    def stop_redirect_process(self) -> bool:
+    def stop_redirect_thread(self) -> bool:
         killed = False
-        if self.proc and self.proc.is_alive():
-            while self.proc.is_alive():
-                self.proc.terminate()
+        if self._redirect_thread and self._redirect_thread.is_alive():
+            self._redirect_thread.terminate()
             killed = True
 
         return killed
@@ -117,89 +120,82 @@ class Serial:
         logging.debug(f'occupied {self.port}')
 
     def close(self):
-        self.proc.terminate()
+        self.stop_redirect_thread()
+        self.proc.close()
         self.occupied_ports.pop(self.port, None)
         logging.debug(f'released {self.port}')
 
     @contextlib.contextmanager
-    def disable_redirect_serial(self) -> bool:
+    def disable_redirect_thread(self) -> bool:
         """
-        Close the redirect serial process, and start the redirect process again after yield back
+        kill the redirect thread, and start a new one after got yield back
 
         Yields:
-            True if redirect serial process is been killed
+            True if redirect serial thread is been terminated
         """
-        killed = self.stop_redirect_process()
+        killed = self.stop_redirect_thread()
 
         yield killed
 
         if killed:
-            self.start_redirect_process()
+            self.start_redirect_thread()
 
 
-class _SerialRedirectProcess(multiprocessing.Process):
+class _SerialRedirectThread(threading.Thread):
     """
-    Redirect serial process. All pyserial.Serial methods was also runnable within this class.
-
-    Warning:
-        All attributes under this class or its sub-classes must be serializable.
+    Redirect serial thread
     """
 
-    def __init__(self, msg_queue, port, port_config):
+    def __init__(self, msg_queue: MessageQueue, s: pyserial.Serial):
         self._q = msg_queue
         self._event_q = multiprocessing.Queue()
+        self._s = s
 
-        self.port = port
-        self.port_config = port_config
+        self._block_reading = False
 
-        super().__init__(target=self._forward_io, daemon=True)  # killed by the main process
+        super().__init__(target=self._event_loop, daemon=True)  # killed by the main process
 
-    def _forward_io(self) -> None:
-        _serial = pyserial.serial_for_url(self.port, **self.port_config)
-
-        while _serial.is_open:
-            try:
-                self._event_loop(_serial)
-            except Exception as e:
-                logging.error(e)
-
-    def _event_loop(self, _serial: pyserial.Serial):
+    def _event_loop(self):
         """
         Since pyserial.Serial instance can't be serialized, we pass the `_serial` as an reference of the object
         defined in _forward_io. The pyserial.Serial methods are mocked to send an event to the queue, and the real
         method is running here.
         """
-        try:
-            _e, _args, _kwargs = self._event_q.get_nowait()
-            logging.debug('running method %s with args %s and kwargs %s', _e, _args, _kwargs)
-        except queue.Empty:
-            _e, _args, _kwargs = 'read', [], {}
-
-        if _e == 'read':
+        while True:
             try:
-                s = _serial.read_all()
-                self._q.put(s)
-            except Exception as e:
-                logging.error(e)
-        else:
-            try:
-                getattr(_serial, _e)(*_args, **_kwargs)
-            except Exception as e:
-                logging.error(e)
+                _e = self._event_q.get_nowait()
+            except queue.Empty:
+                _e = 'read'
+            except OSError:
+                return
 
-        time.sleep(0.05)  # set interval
+            if _e == 'read':
+                if self._block_reading:
+                    continue
 
+                try:
+                    s = self._s.read_all()
+                    self._q.put(s)
+                except OSError:
+                    return
+                except Exception as e:
+                    logging.error(e)
 
-def _mock_pyserial_method(name):
-    def real_func(self, *args, **kwargs):
-        logging.debug('Mocking method "%s" with args %s kwargs %s', name, args, kwargs)
-        self._event_q.put((name, args, kwargs))
+            elif _e == 'stop':
+                self._block_reading = True
+            elif _e == 'start':
+                self._block_reading = False
+            elif _e == 'end':
+                return
 
-    return real_func
+            time.sleep(0.05)  # set interval
 
+    def stop_reading(self):
+        self._event_q.put('stop')
 
-# mock pyserial Serial methods into this class
-_pyserial_func = inspect.getmembers(pyserial.Serial, predicate=inspect.isfunction)
-for _f_name, _ in _pyserial_func:
-    if not _f_name.startswith('__'):  # not magic functions
-        setattr(_SerialRedirectProcess, _f_name, _mock_pyserial_method(_f_name))
+    def start_reading(self):
+        self._event_q.put('start')
+
+    def terminate(self):
+        self._event_q.put('end')
+        self.join()


### PR DESCRIPTION
trade off to #67 

1. we need direct access to pyserial instance
2. pyserial object cannot be pickled
3. since it's using file descriptor, `NamespaceProxy` won't work for windows as well

can use thread only...