### PR TITLE
Support rfc2217 connections

### DIFF
--- a/pytest-embedded-serial/pytest_embedded_serial/serial.py
+++ b/pytest-embedded-serial/pytest_embedded_serial/serial.py
@@ -57,7 +57,7 @@ class Serial:
 
         self.baud = baud
 
-        if isinstance(port, pyserial.Serial):
+        if isinstance(port, pyserial.SerialBase):
             self.proc = port
             self.proc.timeout = self.DEFAULT_PORT_CONFIG['timeout']  # set read timeout
             self.port = self.proc.port


### PR DESCRIPTION
RFC2217 enables remote serial ports over TCP. It's supported by esptool and even [documented](https://docs.espressif.com/projects/esptool/en/latest/esp32/esptool/remote-serial-ports.html#remote-serial-ports). 

This fix allows using RFC2217 ports with pytest-embedded.