### PR TITLE
pytest_embedded_arduino/: Separated flash settings for each target to fix H2

### DIFF
--- a/pytest-embedded-arduino/pytest_embedded_arduino/app.py
+++ b/pytest-embedded-arduino/pytest_embedded_arduino/app.py
@@ -17,7 +17,14 @@ class ArduinoApp(App):
     """
 
     #: dict of flash settings
-    flash_settings = {'flash_mode': 'dio', 'flash_size': 'detect', 'flash_freq': '80m'}
+    flash_settings = {
+        'esp32': {'flash_mode': 'dio', 'flash_size': 'detect', 'flash_freq': '80m'},
+        'esp32s2': {'flash_mode': 'dio', 'flash_size': 'detect', 'flash_freq': '80m'},
+        'esp32c3': {'flash_mode': 'dio', 'flash_size': 'detect', 'flash_freq': '80m'},
+        'esp32s3': {'flash_mode': 'dio', 'flash_size': 'detect', 'flash_freq': '80m'},
+        'esp32c6': {'flash_mode': 'dio', 'flash_size': 'detect', 'flash_freq': '80m'},
+        'esp32h2': {'flash_mode': 'dio', 'flash_size': 'detect', 'flash_freq': '48m'},
+    }
 
     #: dict of binaries' offset.
     binary_offsets = {

--- a/pytest-embedded-arduino/pytest_embedded_arduino/serial.py
+++ b/pytest-embedded-arduino/pytest_embedded_arduino/serial.py
@@ -57,7 +57,7 @@ class ArduinoSerial(EspSerial):
             'chip': self.app.target,
         }
 
-        default_kwargs.update(self.app.flash_settings)
+        default_kwargs.update(self.app.flash_settings[self.app.target])
         flash_args = EsptoolArgs(**default_kwargs)
 
         try:


### PR DESCRIPTION
I have separated flash_setting for each SoC, as the H2 cannot flash on default 80MHz.
Tested locally on H2.