### PR TITLE
local cache for port-target-cache between session (RDT-501)

### DIFF
--- a/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
+++ b/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
@@ -63,7 +63,7 @@ class EspSerial(Serial):
     ) -> None:
         self._meta = meta
 
-        esptool_target = beta_target or target
+        esptool_target = beta_target or target or 'auto'
         if port is None:
             available_ports = esptool.get_port_list()
             ports = list(set(available_ports) - set(self.occupied_ports.keys()))

--- a/pytest-embedded-serial-esp/tests/test_esp.py
+++ b/pytest-embedded-serial-esp/tests/test_esp.py
@@ -1,5 +1,7 @@
 import re
 
+import pytest
+
 
 def test_detect_port(testdir):
     testdir.makepyfile(
@@ -55,3 +57,42 @@ def test_detect_port_with_cache(testdir, caplog, first_index_of_messages):
     first_index_of_messages(
         re.compile('^hit port-target cache: .+ - esp32$', re.MULTILINE), caplog.messages, esp32s2_hit_cache_index + 1
     )
+
+
+def test_detect_port_with_local_cache(testdir):
+    pytest.global_port_target_cache = {}
+
+    testdir.makepyfile(r"""
+    import pytest
+
+    def test_empty_port_target_cache_before_init_devices(port_target_cache):
+        assert isinstance(port_target_cache, dict)
+        assert port_target_cache == pytest.global_port_target_cache
+
+    def test_init_devices(dut, port_target_cache):
+        pytest.global_port_target_cache = port_target_cache
+
+    def test_empty_port_target_cache_after_init_devices(port_target_cache):
+        assert port_target_cache == pytest.global_port_target_cache
+    """)
+    result = testdir.runpytest(
+        '-s',
+        '--embedded-services', 'esp',
+        '--cache-dir', './cache-test',
+        '--count', '2',
+    )
+    result.assert_outcomes(passed=3)
+
+    testdir.makepyfile("""
+    import pytest
+
+    def test_load_local_saved_port_target_cache(port_target_cache):
+        assert port_target_cache == pytest.global_port_target_cache
+    """)
+    result = testdir.runpytest(
+        '-s',
+        '--embedded-services', 'esp',
+        '--cache-dir', './cache-test',
+        '--count', '2',
+    )
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Implement local cache for port-target-cache between session with use shelve.
Change function port_target_cache to yield fixtures type.
closes #182 