### PR TITLE
feat: Support hard_reset without stub (RDT-542)

### DIFF
--- a/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
+++ b/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
@@ -202,7 +202,7 @@ class EspSerial(Serial):
     def _start(self):
         self.hard_reset()
 
-    @use_esptool()
+    @use_esptool(hard_reset_after=True, no_stub=True)
     def hard_reset(self):
         """Hard reset your espressif device"""
         pass


### PR DESCRIPTION
The method `hard_reset()` of the class `EspSerial` used the default arguments of the decorator use_esptool(), due to which stub is required for performing a hard_reset().

This support for `no_stub` allows usage of the package with the newer chips for whom `flasher_stub` support has not been added yet. 