### PR TITLE
feature: Wokwi simulation support (RDT-551)

### DIFF
--- a/foreach.sh
+++ b/foreach.sh
@@ -10,6 +10,7 @@ DEFAULT_PACKAGES=" \
   pytest-embedded-jtag \
   pytest-embedded-qemu \
   pytest-embedded-arduino \
+  pytest-embedded-wokwi \
 "
 
 action=${1:-"install"}

--- a/pytest-embedded-wokwi/LICENSE
+++ b/pytest-embedded-wokwi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Espressif Systems (Shanghai) Co. Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pytest-embedded-wokwi/README.md
+++ b/pytest-embedded-wokwi/README.md
@@ -1,1 +1,37 @@
 ### pytest-embedded-wokwi
+
+pytest-embedded service for running tests on [Wokwi](https://wokwi.com/ci) instead of the real target.
+
+Wokwi supports most ESP32 targets, including: esp32, esp32s2, esp32s3, esp32c3, esp32c6, and esp32h2. In addition, it supports a [wide range of peripherals](https://docs.wokwi.com/getting-started/supported-hardware), including sensors, displays, motors, and debugging tools.
+
+Running the tests with Wokwi requires an internet connection. Your firmware is uploaded to the Wokwi server for the duration of the simulation, but it is not saved on the server. On-premises Wokwi installations are available for enterprise customers.
+
+## Wokwi CLI installation
+
+The Wokwi plugin uses the [Wokwi CLI](https://github.com/wokwi/wokwi-cli) to interact with the wokwi simulation server. You can download the precompiled CLI binaries from the [releases page](https://github.com/wokwi/wokwi-cli/releases). Alternatively, on Linux or Mac OS, you can install the CLI using the following command:
+
+```bash
+curl -L https://wokwi.com/ci/install.sh | sh
+```
+
+And on Windows:
+
+```powershell
+iwr https://wokwi.com/ci/install.ps1 -useb | iex
+```
+
+## API Tokens
+
+Before using this plugin, you need to create a free Wokwi account and [generate an API key](https://wokwi.com/dashboard/ci). You can then set the `WOKWI_CLI_TOKEN` environment variable to the API key.
+
+Linux / Mac OS / WSL:
+
+```bash
+export WOKWI_CLI_TOKEN="your-api-key"
+```
+
+Windows PowerShell:
+
+```powershell
+$env:WOKWI_CLI_TOKEN="your-api-key"
+```

--- a/pytest-embedded-wokwi/README.md
+++ b/pytest-embedded-wokwi/README.md
@@ -1,0 +1,1 @@
+### pytest-embedded-wokwi

--- a/pytest-embedded-wokwi/pyproject.toml
+++ b/pytest-embedded-wokwi/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "flit_core.buildapi"
 name = "pytest-embedded-wokwi"
 authors = [
     {name = "Fu Hanxi", email = "fuhanxi@espressif.com"},
+    {name = "Uri Shaked", email = "uri@wokwi.com"},
 ]
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/pytest-embedded-wokwi/pyproject.toml
+++ b/pytest-embedded-wokwi/pyproject.toml
@@ -1,0 +1,105 @@
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "pytest-embedded-wokwi"
+authors = [
+    {name = "Fu Hanxi", email = "fuhanxi@espressif.com"},
+]
+readme = "README.md"
+license = {file = "LICENSE"}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Framework :: Pytest",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python",
+    "Topic :: Software Development :: Testing",
+]
+dynamic = ["version", "description"]
+requires-python = ">=3.7"
+
+dependencies = [
+    "pytest-embedded~=1.3.5",
+]
+
+[project.optional-dependencies]
+idf = [
+    "pytest-embedded-idf~=1.3.5",
+]
+
+[project.urls]
+homepage = "https://github.com/espressif/pytest-embedded"
+repository = "https://github.com/espressif/pytest-embedded"
+documentation = "https://docs.espressif.com/projects/pytest-embedded/en/latest/"
+changelog = "https://github.com/espressif/pytest-embedded/blob/main/CHANGELOG.md"
+
+[tool.isort]
+profile = 'black'
+
+[tool.black]
+line-length = 120
+target-version = ['py37']
+force-exclude = '/tests/'
+skip-string-normalization = true
+
+[tool.ruff]
+select = [
+    'F',  # Pyflakes
+    'E',  # pycodestyle
+    'W',  # pycodestyle
+#    'C90',  # mccabe
+#    'I',  # isort
+#    'N',  # pep8-naming
+#    'D',  # pydocstyle
+#    'UP',  #  pyupgrade
+#    'YTT',  # flake8-2020
+#    'ANN',  # flake8-annotations
+#    'S',  # flake8-bandit
+#    'BLE',  # flake8-blind-except
+#    'FBT',  # flake8-boolean-trap
+#    'B',  # flake8-bugbear
+#    'A',  # flake8-builtins
+#    'COM',  # flake8-commas
+#    'C4',  #  flake8-comprehensions
+#    'DTZ',  # flake8-datetimez
+#    'T10',  # flake8-debugger
+#    'DJ',  #  flake8-django
+#    'EM',  #  flake8-errmsg
+#    'EXE',  # flake8-executable
+#    'ISC',  # flake8-implicit-str-concat
+#    'ICN',  # flake8-import-conventions
+#    'G',  # flake8-logging-format
+#    'INP',  # flake8-no-pep420
+#    'PIE',  # flake8-pie
+#    'T20',  # flake8-print
+#    'PYI',  # flake8-pyi
+#    'PT',  #  flake8-pytest-style
+#    'Q',  # flake8-quotes
+#    'RSE',  # flake8-raise
+#    'RET',  # flake8-return
+#    'SLF',  # flake8-self
+#    'SIM',  # flake8-simplify
+#    'TID',  # flake8-tidy-imports
+#    'TCH',  # flake8-type-checking
+#    'ARG',  # flake8-unused-arguments
+#    'PTH',  # flake8-use-pathlib
+#    'ERA',  # eradicate
+#    'PD',  #  pandas-vet
+#    'PGH',  # pygrep-hooks
+#    'PL',  #  Pylint
+#    'TRY',  # tryceratops
+#    'NPY',  # NumPy-specific rules
+#    'RUF',  # Ruff-specific rules
+]
+line-length = 120
+target-version = "py37"

--- a/pytest-embedded-wokwi/pyproject.toml
+++ b/pytest-embedded-wokwi/pyproject.toml
@@ -30,6 +30,7 @@ requires-python = ">=3.7"
 
 dependencies = [
     "pytest-embedded~=1.3.5",
+    "toml~=0.10.2",
 ]
 
 [project.optional-dependencies]

--- a/pytest-embedded-wokwi/pytest_embedded_wokwi/__init__.py
+++ b/pytest-embedded-wokwi/pytest_embedded_wokwi/__init__.py
@@ -1,0 +1,11 @@
+"""Make pytest-embedded plugin work with the Wokwi CLI."""
+
+from .dut import WokwiDut  # noqa
+from .wokwi_cli import WokwiCLI  # noqa
+
+__all__ = [
+    'WokwiCLI',
+    'WokwiDut',
+]
+
+__version__ = '1.3.5'

--- a/pytest-embedded-wokwi/pytest_embedded_wokwi/dut.py
+++ b/pytest-embedded-wokwi/pytest_embedded_wokwi/dut.py
@@ -1,0 +1,25 @@
+from typing import AnyStr
+
+from pytest_embedded.dut import Dut
+
+from .wokwi_cli import WokwiCLI
+
+
+class WokwiDut(Dut):
+    """
+    Wokwi DUT class
+    """
+
+    def __init__(
+        self,
+        wokwi: WokwiCLI,
+        **kwargs,
+    ) -> None:
+        self.wokwi = wokwi
+
+        super().__init__(**kwargs)
+
+        self._hard_reset_func = self.wokwi._hard_reset
+
+    def write(self, s: AnyStr) -> None:
+        self.wokwi.write(s)

--- a/pytest-embedded-wokwi/pytest_embedded_wokwi/idf.py
+++ b/pytest-embedded-wokwi/pytest_embedded_wokwi/idf.py
@@ -1,0 +1,14 @@
+import typing as t
+from pathlib import Path
+
+if t.TYPE_CHECKING:
+    from pytest_embedded_idf.app import IdfApp
+
+
+class IDFFirmwareResolver:
+    """
+    IDFFirmwareResolver class
+    """
+
+    def resolve_firmware(self, app: 'IdfApp'):
+        return Path(app.binary_path, 'flasher_args.json')

--- a/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
+++ b/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
@@ -8,6 +8,8 @@ import toml
 from pytest_embedded import __version__
 from pytest_embedded.log import DuplicateStdoutPopen
 
+from .idf import IDFFirmwareResolver
+
 if t.TYPE_CHECKING:
     from pytest_embedded_idf.app import IdfApp
 
@@ -33,6 +35,7 @@ class WokwiCLI(DuplicateStdoutPopen):
 
     def __init__(
         self,
+        firmware_resolver: IDFFirmwareResolver,
         wokwi_cli_path: t.Optional[str] = None,
         app: t.Optional['IdfApp'] = None,
         **kwargs,
@@ -42,6 +45,7 @@ class WokwiCLI(DuplicateStdoutPopen):
             wokwi_cli_path: Wokwi CLI arguments
         """
         self.app = app
+        self.firmware_resolver = firmware_resolver
 
         self.create_wokwi_toml()
         self.create_diagram_json()
@@ -59,7 +63,7 @@ class WokwiCLI(DuplicateStdoutPopen):
 
     def create_wokwi_toml(self):
         app = self.app
-        flasher_args = Path(app.binary_path, 'flasher_args.json')
+        flasher_args = self.firmware_resolver.resolve_firmware(app)
         wokwi_toml_path = os.path.join(app.app_path, 'wokwi.toml')
         firmware_path = Path(flasher_args).relative_to(app.app_path).as_posix()
         elf_path = Path(app.elf_file).relative_to(app.app_path).as_posix()

--- a/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
+++ b/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
@@ -1,0 +1,100 @@
+import json
+import os
+import typing as t
+
+from pytest_embedded import __version__
+from pytest_embedded.log import DuplicateStdoutPopen
+
+if t.TYPE_CHECKING:
+    from pytest_embedded_idf.app import IdfApp
+
+
+target_to_board = {
+    'esp32': 'board-esp32-devkit-c-v4',
+    'esp32c3': 'board-esp32-c3-devkitm-1',
+    'esp32c6': 'board-esp32-c6-devkitc-1',
+    'esp32h2': 'board-esp32-h2-devkitm-1',
+    'esp32s2': 'board-esp32-s2-devkitm-1',
+    'esp32s3': 'board-esp32-s3-devkitc-1',
+}
+
+
+class WokwiCLI(DuplicateStdoutPopen):
+    """
+    WokwiCLI class
+    """
+
+    SOURCE = 'Wokwi'
+
+    WOKWI_CLI_PATH = 'wokwi-cli'
+
+    def __init__(
+        self,
+        wokwi_cli_path: t.Optional[str] = None,
+        app: t.Optional['IdfApp'] = None,
+        **kwargs,
+    ):
+        """
+        Args:
+            wokwi_cli_path: Wokwi CLI arguments
+        """
+        self.app = app
+
+        bin_list = []
+        app_binary = None
+        for file in app.flash_files:
+            if not os.path.exists(file.file_path):
+                raise ValueError(f'Firmware binary file doesn\'t exist: {file.file_path}')
+            file_rel_path = os.path.relpath(app.elf_file, app.app_path)
+            bin_list.append(f"'{file.offset:#x} {file_rel_path}',")
+            # The following is a workaround until wokwi-cli supports multiple binaries
+            if file.offset == 0x10000:
+                app_binary = file_rel_path
+
+        bin_list_toml = '\n  '.join(bin_list)
+        with open(os.path.join(app.app_path, 'wokwi.toml'), 'wt') as f:
+            f.write(
+                f"""
+[wokwi]
+version = 1
+generatedBy = 'pytest-embedded-wokwi {__version__}'
+firmware = '{app_binary}'
+elf = '{os.path.relpath(app.elf_file, app.app_path)}'
+
+# We don't support multiple binaries yet, so this will be ignored for now:
+flash = [
+  {bin_list_toml}
+]
+"""
+            )
+
+        # TODO: Check if diagram already exist and update it?
+        diagram = {
+            'version': 1,
+            'author': 'Uri Shaked',
+            'editor': 'wokwi',
+            'parts': [{'type': target_to_board[app.target], 'id': 'esp'}],
+            'connections': [
+                ['esp:TX', '$serialMonitor:RX', '', []],
+                ['esp:RX', '$serialMonitor:TX', '', []],
+            ],
+        }
+        with open(os.path.join(app.app_path, 'diagram.json'), 'wt') as f:
+            f.write(json.dumps(diagram))
+
+        wokwi_cli = wokwi_cli_path or self.wokwi_cli_executable
+
+        super().__init__(
+            cmd=[wokwi_cli, app.app_path],
+            **kwargs,
+        )
+
+    @property
+    def wokwi_cli_executable(self):
+        return self.WOKWI_CLI_PATH
+
+    def _hard_reset(self):
+        """
+        This is a fake hard_reset. Keep this API to keep the consistency.
+        """
+        raise NotImplementedError

--- a/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
+++ b/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
@@ -1,8 +1,10 @@
 import json
+import logging
 import os
 import typing as t
 from pathlib import Path
 
+import toml
 from pytest_embedded import __version__
 from pytest_embedded.log import DuplicateStdoutPopen
 
@@ -40,32 +42,9 @@ class WokwiCLI(DuplicateStdoutPopen):
             wokwi_cli_path: Wokwi CLI arguments
         """
         self.app = app
-        flasher_args = Path(app.binary_path, 'flasher_args.json')
 
-        with open(os.path.join(app.app_path, 'wokwi.toml'), 'wt') as f:
-            f.write(
-                f"""
-[wokwi]
-version = 1
-generatedBy = 'pytest-embedded-wokwi {__version__}'
-firmware = '{Path(flasher_args).relative_to(app.app_path).as_posix()}'
-elf = '{Path(app.elf_file).relative_to(app.app_path).as_posix()}'
-"""
-            )
-
-        # TODO: Check if diagram already exist and update it?
-        diagram = {
-            'version': 1,
-            'author': 'Uri Shaked',
-            'editor': 'wokwi',
-            'parts': [{'type': target_to_board[app.target], 'id': 'esp'}],
-            'connections': [
-                ['esp:TX', '$serialMonitor:RX', '', []],
-                ['esp:RX', '$serialMonitor:TX', '', []],
-            ],
-        }
-        with open(os.path.join(app.app_path, 'diagram.json'), 'wt') as f:
-            f.write(json.dumps(diagram))
+        self.create_wokwi_toml()
+        self.create_diagram_json()
 
         wokwi_cli = wokwi_cli_path or self.wokwi_cli_executable
 
@@ -77,6 +56,67 @@ elf = '{Path(app.elf_file).relative_to(app.app_path).as_posix()}'
     @property
     def wokwi_cli_executable(self):
         return self.WOKWI_CLI_PATH
+
+    def create_wokwi_toml(self):
+        app = self.app
+        flasher_args = Path(app.binary_path, 'flasher_args.json')
+        wokwi_toml_path = os.path.join(app.app_path, 'wokwi.toml')
+        firmware_path = Path(flasher_args).relative_to(app.app_path).as_posix()
+        elf_path = Path(app.elf_file).relative_to(app.app_path).as_posix()
+
+        if os.path.exists(wokwi_toml_path):
+            with open(wokwi_toml_path, 'rt') as f:
+                toml_data = toml.load(f)
+
+            if 'wokwi' not in toml_data:
+                toml_data['wokwi'] = {'version': 1}
+
+            wokwi_table = toml_data['wokwi']
+            if wokwi_table.get('firmware') == firmware_path and wokwi_table.get('elf') == elf_path:
+                # No need to update
+                return
+
+            wokwi_table.update({'firmware': firmware_path, 'elf': elf_path})
+        else:
+            toml_data = {
+                'wokwi': {
+                    'version': 1,
+                    'generatedBy': f'pytest-embedded-wokwi {__version__}',
+                    'firmware': firmware_path,
+                    'elf': elf_path,
+                }
+            }
+
+        with open(wokwi_toml_path, 'wt') as f:
+            toml.dump(toml_data, f)
+
+    def create_diagram_json(self):
+        app = self.app
+        diagram_json_path = os.path.join(app.app_path, 'diagram.json')
+        target_board = target_to_board[app.target]
+
+        if os.path.exists(diagram_json_path):
+            with open(diagram_json_path, 'rt') as f:
+                json_data = json.load(f)
+            if not any(part['type'] == target_board for part in json_data['parts']):
+                logging.warning(
+                    f'diagram.json exists, no part with type "{target_board}" found. '
+                    + 'You may need to update the diagram.json file manually to match the target board.'
+                )
+            return
+
+        diagram = {
+            'version': 1,
+            'author': 'Uri Shaked',
+            'editor': 'wokwi',
+            'parts': [{'type': target_board, 'id': 'esp'}],
+            'connections': [
+                ['esp:TX', '$serialMonitor:RX', ''],
+                ['esp:RX', '$serialMonitor:TX', ''],
+            ],
+        }
+        with open(diagram_json_path, 'wt') as f:
+            f.write(json.dumps(diagram, indent=2))
 
     def _hard_reset(self):
         """

--- a/pytest-embedded-wokwi/tests/test_wokwi.py
+++ b/pytest-embedded-wokwi/tests/test_wokwi.py
@@ -1,0 +1,38 @@
+import os
+import shutil
+
+import pytest
+
+wokwi_cli_required = pytest.mark.skipif(
+    shutil.which('wokwi-cli') is None,
+    reason='Please make sure that `wokwi-cli` is in your PATH env var. '
+    + 'To install: https://docs.wokwi.com/wokwi-ci/getting-started#cli-installation'
+)
+
+wokwi_token_required = pytest.mark.skipif(
+    os.getenv('WOKWI_CLI_TOKEN') is None,
+    reason='Please make sure that `WOKWI_CLI_TOKEN` env var is set. Get a token here: https://wokwi.com/dashboard/ci'
+)
+
+
+@wokwi_cli_required
+@wokwi_token_required
+def test_pexpect_by_wokwi_esp32(testdir):
+    testdir.makepyfile("""
+        import pexpect
+        import pytest
+
+        def test_pexpect_by_wokwi(dut):
+            dut.expect('Hello world!')
+            dut.expect('Restarting')
+            with pytest.raises(pexpect.TIMEOUT):
+                dut.expect('foo bar not found', timeout=1)
+    """)
+
+    result = testdir.runpytest(
+        '-s',
+        '--embedded-services', 'idf,wokwi',
+        '--app-path', os.path.join(testdir.tmpdir, 'hello_world_esp32'),
+    )
+
+    result.assert_outcomes(passed=1)

--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -51,7 +51,6 @@ if t.TYPE_CHECKING:
     from pytest_embedded_jtag import Gdb, OpenOcd
     from pytest_embedded_qemu import Qemu
     from pytest_embedded_serial import Serial
-
     from pytest_embedded_wokwi import WokwiCLI
 
 

--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -51,6 +51,7 @@ if t.TYPE_CHECKING:
     from pytest_embedded_jtag import Gdb, OpenOcd
     from pytest_embedded_qemu import Qemu
     from pytest_embedded_serial import Serial
+
     from pytest_embedded_wokwi import WokwiCLI
 
 
@@ -1199,12 +1200,14 @@ def _fixture_classes_and_options(
                 from pytest_embedded_wokwi import WokwiCLI
 
                 classes[fixture] = WokwiCLI
-                kwargs[fixture] = {
-                    'wokwi_cli_path': wokwi_cli_path,
-                    'msg_queue': msg_queue,
-                    'app': None,
-                    'meta': _meta,
-                }
+                kwargs[fixture].update(
+                    {
+                        'wokwi_cli_path': wokwi_cli_path,
+                        'msg_queue': msg_queue,
+                        'app': None,
+                        'meta': _meta,
+                    }
+                )
         elif fixture == 'dut':
             classes[fixture] = Dut
             kwargs[fixture] = {
@@ -1228,7 +1231,13 @@ def _fixture_classes_and_options(
                 if 'idf' in _services:
                     from pytest_embedded_idf.unity_tester import IdfUnityDutMixin
 
+                    from pytest_embedded_wokwi.idf import IDFFirmwareResolver
+
+                    kwargs['wokwi'].update({'firmware_resolver': IDFFirmwareResolver()})
+
                     mixins[fixture].append(IdfUnityDutMixin)
+                else:
+                    raise SystemExit('wokwi service should be used together with idf service')
             if 'qemu' in _services:
                 from pytest_embedded_qemu import QemuDut
 
@@ -1373,7 +1382,6 @@ def wokwi(_fixture_classes_and_options: ClassCliOptions, app) -> t.Optional['Wok
 
     if 'app' in kwargs and kwargs['app'] is None:
         kwargs['app'] = app
-
     return cls(**_drop_none_kwargs(kwargs))
 
 

--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -52,6 +52,8 @@ if t.TYPE_CHECKING:
     from pytest_embedded_qemu import Qemu
     from pytest_embedded_serial import Serial
 
+    from pytest_embedded_wokwi import WokwiCLI
+
 
 _T = t.TypeVar('_T')
 
@@ -118,6 +120,7 @@ def pytest_addoption(parser):
         '- jtag: openocd and gdb\n'
         '- qemu: use qemu simulator instead of the real target\n'
         '- arduino: auto-detect more app info with arduino specific rules, auto flash-in\n'
+        '- wokwi: use wokwi simulator instead of the real target\n'
         'All the related CLI options are under the groups named by "embedded-<service>"',
     )
     base_group.addoption('--app-path', help='App path')
@@ -240,6 +243,12 @@ def pytest_addoption(parser):
     qemu_group.addoption(
         '--keyfile',
         help='Flash Encryption (pre-encrypted workflow) key path. (Default: None)',
+    )
+
+    wokwi_group = parser.getgroup('embedded-wokwi')
+    wokwi_group.addoption(
+        '--wokwi-cli-path',
+        help='Path to the wokwi-cli program (Default: "wokwi-cli")',
     )
 
 
@@ -949,6 +958,16 @@ def keyfile(request: FixtureRequest) -> t.Optional[str]:
     return _request_param_or_config_option_or_default(request, 'keyfile', None)
 
 
+#########
+# Wokwi #
+#########
+@pytest.fixture
+@multi_dut_argument
+def wokwi_cli_path(request: FixtureRequest) -> t.Optional[str]:
+    """Enable parametrization for the same cli option"""
+    return _request_param_or_config_option_or_default(request, 'wokwi_cli_path', None)
+
+
 ####################
 # Private Fixtures #
 ####################
@@ -1009,6 +1028,7 @@ def _fixture_classes_and_options(
     qemu_prog_path,
     qemu_cli_args,
     qemu_extra_args,
+    wokwi_cli_path,
     skip_regenerate_image,
     encrypt,
     keyfile,
@@ -1175,6 +1195,17 @@ def _fixture_classes_and_options(
                     'app': None,
                     'meta': _meta,
                 }
+        elif fixture == 'wokwi':
+            if 'wokwi' in _services:
+                from pytest_embedded_wokwi import WokwiCLI
+
+                classes[fixture] = WokwiCLI
+                kwargs[fixture] = {
+                    'wokwi_cli_path': wokwi_cli_path,
+                    'msg_queue': msg_queue,
+                    'app': None,
+                    'meta': _meta,
+                }
         elif fixture == 'dut':
             classes[fixture] = Dut
             kwargs[fixture] = {
@@ -1185,6 +1216,20 @@ def _fixture_classes_and_options(
                 'test_case_name': test_case_name,
                 'meta': _meta,
             }
+            if 'wokwi' in _services:
+                from pytest_embedded_wokwi import WokwiDut
+
+                classes[fixture] = WokwiDut
+                kwargs[fixture].update(
+                    {
+                        'wokwi': None,
+                    }
+                )
+
+                if 'idf' in _services:
+                    from pytest_embedded_idf.unity_tester import IdfUnityDutMixin
+
+                    mixins[fixture].append(IdfUnityDutMixin)
             if 'qemu' in _services:
                 from pytest_embedded_qemu import QemuDut
 
@@ -1319,6 +1364,22 @@ def qemu(_fixture_classes_and_options: ClassCliOptions, app) -> t.Optional['Qemu
 
 @pytest.fixture
 @multi_dut_generator_fixture
+def wokwi(_fixture_classes_and_options: ClassCliOptions, app) -> t.Optional['WokwiCLI']:
+    """A wokwi subprocess that could read/redirect/write"""
+    if 'wokwi' not in _fixture_classes_and_options.classes:
+        return None
+
+    cls = _fixture_classes_and_options.classes['wokwi']
+    kwargs = _fixture_classes_and_options.kwargs['wokwi']
+
+    if 'app' in kwargs and kwargs['app'] is None:
+        kwargs['app'] = app
+
+    return cls(**_drop_none_kwargs(kwargs))
+
+
+@pytest.fixture
+@multi_dut_generator_fixture
 def dut(
     _fixture_classes_and_options: ClassCliOptions,
     openocd: t.Optional['OpenOcd'],
@@ -1326,6 +1387,7 @@ def dut(
     app: App,
     serial: t.Optional[t.Union['Serial', 'LinuxSerial']],
     qemu: t.Optional['Qemu'],
+    wokwi: t.Optional['WokwiCLI'],
 ) -> t.Union[Dut, t.List[Dut]]:
     """
     A device under test (DUT) object that could gather output from various sources and redirect them to the pexpect
@@ -1356,7 +1418,8 @@ def dut(
                 kwargs[k] = gdb
             elif k == 'qemu':
                 kwargs[k] = qemu
-
+            elif k == 'wokwi':
+                kwargs[k] = wokwi
     return cls(**_drop_none_kwargs(kwargs), mixins=mixins)
 
 

--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -51,7 +51,6 @@ if t.TYPE_CHECKING:
     from pytest_embedded_jtag import Gdb, OpenOcd
     from pytest_embedded_qemu import Qemu
     from pytest_embedded_serial import Serial
-
     from pytest_embedded_wokwi import WokwiCLI
 
 
@@ -1230,7 +1229,6 @@ def _fixture_classes_and_options(
 
                 if 'idf' in _services:
                     from pytest_embedded_idf.unity_tester import IdfUnityDutMixin
-
                     from pytest_embedded_wokwi.idf import IDFFirmwareResolver
 
                     kwargs['wokwi'].update({'firmware_resolver': IDFFirmwareResolver()})

--- a/pytest-embedded/pytest_embedded/utils.py
+++ b/pytest-embedded/pytest_embedded/utils.py
@@ -21,6 +21,7 @@ SERVICE_LIB_NAMES = {
     'jtag': f'{BASE_LIB_NAME}-jtag',
     'qemu': f'{BASE_LIB_NAME}-qemu',
     'arduino': f'{BASE_LIB_NAME}-arduino',
+    'wokwi': f'{BASE_LIB_NAME}-wokwi',
 }
 
 FIXTURES_SERVICES = {
@@ -29,7 +30,8 @@ FIXTURES_SERVICES = {
     'openocd': ['jtag'],
     'gdb': ['jtag'],
     'qemu': ['qemu'],
-    'dut': ['base', 'serial', 'jtag', 'qemu', 'idf'],
+    'wokwi': ['wokwi'],
+    'dut': ['base', 'serial', 'jtag', 'qemu', 'idf', 'wokwi'],
 }
 
 _T = t.TypeVar('_T')


### PR DESCRIPTION
Functional implementation draft. Tested with https://github.com/espressif/gh-esp-test-template on simulated ESP32C6.

<strike>The Wokwi CLI still has no support for specifying multiple flash images. You can either give it an application binary file or elf file to load at 0x10000, using a default bootloader and partition table, or specify a full flash image to load. I'm still trying to figure out what's the best way to address it. Meanwhile, we only provide the app image to the CLI as a workaround.</strike>

Also, we can automatically download the CLI for the user, in case it's not installed. Not sure if this is a good idea, and where we should install it. It's distributed as a single binary, and currently [supports](https://github.com/wokwi/wokwi-cli/releases/tag/v0.6.7) Linux (arm, x64), MacOS (arm, x64) and Windows (x64). 

I'd appreciate your guidance on how to move forward with this.

Here's the output from the test setup I used, for reference:

```
(pytest) PS C:\p\gh-esp-test-template\test_app> pytest --target=esp32-c6 --embedded-services idf,wokwi
========================================================= test session starts ==========================================================
platform win32 -- Python 3.8.10, pytest-7.4.2, pluggy-1.3.0
rootdir: C:\p\gh-esp-test-template\test_app
configfile: pytest.ini
plugins: cov-4.1.0, embedded-1.3.5, rerunfailures-12.0
collected 1 item

test_app.py::test_app
------------------------------------------------------------ live log setup ------------------------------------------------------------ 
2023-09-25 23:11:24 INFO Executing wokwi-cli C:\p\gh-esp-test-template\test_app
2023-09-25 23:11:24 Wokwi CLI v0.6.7 (b824d8cb0edc)
2023-09-25 23:11:25 Connected to Wokwi Simulation API 1.0.0-20230922-g99ff9b94
2023-09-25 23:11:26 Starting simulation...
2023-09-25 23:11:27 ESP-ROM:esp32c6-20220919
2023-09-25 23:11:27
2023-09-25 23:11:27 Build:Sep 19 2022
2023-09-25 23:11:27 rst:0x1 (POWERON),boot:0x5c (SPI_FAST_FLASH_BOOT)
2023-09-25 23:11:27 SPIWP:0xee
2023-09-25 23:11:27 mode:DIO, clock div:2
2023-09-25 23:11:27 load:0x40875720,len:0x126c
2023-09-25 23:11:27 load:0x4086c410,len:0x704
2023-09-25 23:11:27 load:0x4086e610,len:0x2ae0
2023-09-25 23:11:27 SHA-256 comparison failed:
2023-09-25 23:11:27 Calculated: f5b31c96161053e152c0c7cb85092e2fd16385d8e5ebf950cfc21c815848383a
2023-09-25 23:11:27 Expected: 117a5a689f626f77701cc2df471cb76b8a20232ff4425b900e23bf4041d0c79b
2023-09-25 23:11:27 Attempting to boot anyway...
2023-09-25 23:11:27 entry 0x4086c410
2023-09-25 23:11:27 I (20) cpu_start: Unicore app
2023-09-25 23:11:27 I (20) cpu_start: Pro cpu up.
2023-09-25 23:11:27 W (10) clk: esp_perip_clk_init() has not been implemented yet
2023-09-25 23:11:27 I (11) cpu_start: Pro cpu start user code
2023-09-25 23:11:27 I (11) cpu_start: cpu freq: 160000000 Hz
2023-09-25 23:11:27
2023-09-25 23:11:27 I (11) cpu_start: Application information:
2023-09-25 23:11:27 I (11) cpu_start: Project name:     example_test_app
2023-09-25 23:11:27 I (11) cpu_start: App version:      681415e-dirty
2023-09-25 23:11:27 I (11) cpu_start: Compile time:     Sep 24 2023 12:07:49
2023-09-25 23:11:27 I (11) cpu_start: ELF file SHA256:  000000000...
2023-09-25 23:11:27 I (11) cpu_start: ESP-IDF:          v5.2-dev-2934-g3b748a6cb7
2023-09-25 23:11:28 I (12) cpu_start: Min chip rev:     v0.0
2023-09-25 23:11:28
2023-09-25 23:11:28 I (12) cpu_start: Max chip rev:     v0.99
2023-09-25 23:11:28 I (12) cpu_start: Chip rev:         v0.0
2023-09-25 23:11:28 I (12) heap_init: Initializing. RAM available for dynamic allocation:
2023-09-25 23:11:28 I (12) heap_init: At 4080BBD0 len 00070A40 (450 KiB): D/IRAM
2023-09-25 23:11:28 I (12) heap_init: At 4087C610 len 00002F54 (11 KiB): STACK/DIRAM
2023-09-25 23:11:28 I (13) heap_init: At 50000000 len 00003FE8 (15 KiB): RTCRAM
2023-09-25 23:11:28 I (13) spi_flash: detected chip: generic
2023-09-25 23:11:28 I (13) spi_flash: flash io: dio
2023-09-25 23:11:28 I (13) sleep: Configure to isolate all GPIO pins in sleep state
2023-09-25 23:11:28 I (14) sleep: Enable automatic switching of GPIO sleep configuration
2023-09-25 23:11:28 I (14) coexist: coex firmware version: 8770c12
2023-09-25 23:11:28 I (14) coexist: coexist rom version 5b8dcfa
2023-09-25 23:11:28 I (14) app_start: Starting scheduler on CPU0
2023-09-25 23:11:28
2023-09-25 23:11:28 I (14) main_task: Started on CPU0
2023-09-25 23:11:28 I (64) main_task: Calling app_main()
2023-09-25 23:11:28 Unity test run 1 of 1
2023-09-25 23:11:28 TEST(testable, mean_of_empty) PASS
2023-09-25 23:11:28 TEST(testable, mean_of_vector) PASS
2023-09-25 23:11:28 IGNORE_TEST(testable, test_fail)
2023-09-25 23:11:28
2023-09-25 23:11:28 -----------------------
2023-09-25 23:11:28 3 Tests 0 Failures 1 Ignored
2023-09-25 23:11:28 OK
2023-09-25 23:11:28
2023-09-25 23:11:28 Tests finished, rc=0
2023-09-25 23:11:28 I (74) main_task: Returned from app_main()
PASSED
---------------------------------------------------------- live log teardown ----------------------------------------------------------- 
2023-09-25 23:11:28 INFO Created unity output junit report: C:\Users\Uri\AppData\Local\Temp\pytest-embedded\2023-09-25_20-11-24-643490\test_app\dut.xml


========================================================== 1 passed in 3.77s =========================================================== 
```