### PR TITLE
ref: use esptool main instead other func

### DIFF
--- a/pytest-embedded-arduino/pytest_embedded_arduino/serial.py
+++ b/pytest-embedded-arduino/pytest_embedded_arduino/serial.py
@@ -51,6 +51,9 @@ class ArduinoSerial(EspSerial):
             flash_settings.append(f'--{k}')
             flash_settings.append(v)
 
+        if self.esp_flash_force:
+            flash_settings.append('--force')
+
         try:
             esptool.main(
                 ['--chip', self.app.target, 'write_flash', *flash_files, *flash_settings],

--- a/pytest-embedded-arduino/pytest_embedded_arduino/serial.py
+++ b/pytest-embedded-arduino/pytest_embedded_arduino/serial.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 import esptool
-from pytest_embedded_serial_esp.serial import EspSerial, EsptoolArgs
+from pytest_embedded_serial_esp.serial import EspSerial
 
 from .app import ArduinoApp
 
@@ -40,33 +40,21 @@ class ArduinoSerial(EspSerial):
         """
         Flash the binary files to the board.
         """
-        flash_files = [
-            (offset, open(path, 'rb')) for (offset, path, encrypted) in self.app.flash_files if not encrypted
-        ]
+        flash_files = []
+        for offset, path, encrypted in self.app.flash_files:
+            if encrypted:
+                continue
+            flash_files.extend((str(offset), path))
 
-        default_kwargs = {
-            'addr_filename': flash_files,
-            'encrypt_files': None,
-            'no_stub': False,
-            'compress': True,
-            'verify': False,
-            'ignore_flash_encryption_efuse_setting': False,
-            'erase_all': False,
-            'encrypt': False,
-            'force': False,
-            'chip': self.app.target,
-        }
-
-        default_kwargs.update(self.app.flash_settings[self.app.target])
-        flash_args = EsptoolArgs(**default_kwargs)
+        flash_settings = []
+        for k, v in self.app.flash_settings[self.app.target].items():
+            flash_settings.append(f'--{k}')
+            flash_settings.append(v)
 
         try:
-            self.stub.change_baud(self.esptool_baud)
-            esptool.detect_flash_size(self.stub, flash_args)
-            esptool.write_flash(self.stub, flash_args)
-            self.stub.change_baud(self.baud)
+            esptool.main(
+                ['--chip', self.app.target, 'write_flash', *flash_files, *flash_settings],
+                esp=self.esp,
+            )
         except Exception:
             raise
-        finally:
-            for _, f in flash_files:
-                f.close()

--- a/pytest-embedded-idf/pytest_embedded_idf/serial.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/serial.py
@@ -1,12 +1,11 @@
+import contextlib
 import hashlib
 import logging
-import os
 import tempfile
 from typing import Optional, TextIO, Union
 
 import esptool
-from pytest_embedded.log import live_print_call
-from pytest_embedded_serial_esp.serial import EspSerial, EsptoolArgs
+from pytest_embedded_serial_esp.serial import EspSerial
 
 from .app import IdfApp
 
@@ -84,30 +83,36 @@ class IdfSerial(EspSerial):
         if self.app.bin_file:
             bin_file = self.app.bin_file
         else:
-            live_print_call(
-                [
-                    'esptool.py',
-                    '--chip',
-                    self.app.target,
-                    'elf2image',
-                    self.app.elf_file,
-                    *self.app.write_flash_args,
-                ],
-                msg_queue=self._q,
-            )
+            with contextlib.redirect_stdout(self._q):
+                esptool.main(
+                    [
+                        '--chip',
+                        self.app.target,
+                        'elf2image',
+                        self.app.elf_file,
+                        *self.app.write_flash_args,
+                    ],
+                    esp=self.esp,
+                )
             bin_file = self.app.elf_file.replace('.elf', '.bin')
 
-        live_print_call(
-            [
-                'esptool.py',
-                '--chip',
-                self.app.target,
-                '--no-stub',
-                'load_ram',
-                bin_file,
-            ],
-            msg_queue=self._q,
-        )
+        with contextlib.redirect_stdout(self._q):
+            esptool.main(
+                [
+                    '--chip',
+                    self.app.target,
+                    '--no-stub',
+                    'load_ram',
+                    bin_file,
+                ],
+                esp=self.esp,
+            )
+
+    def _force_flag(self):
+        config = self.app.sdkconfig
+        if any((config.get('CONFIG_SECURE_FLASH_ENC_ENABLED', False), config.get('CONFIG_SECURE_BOOT', False))):
+            return ['--force']
+        return []
 
     @EspSerial.use_esptool()
     def flash(self) -> None:
@@ -122,59 +127,62 @@ class IdfSerial(EspSerial):
             logging.error('No flash settings detected. Skipping auto flash...')
             return
 
-        flash_files = [(file.offset, open(file.file_path, 'rb')) for file in self.app.flash_files if not file.encrypted]
-        encrypt_files = [(file.offset, open(file.file_path, 'rb')) for file in self.app.flash_files if file.encrypted]
-
-        nvs_file = None
-        try:
-            if self.erase_nvs:
-                address = self.app.partition_table['nvs']['offset']
-                size = self.app.partition_table['nvs']['size']
-                nvs_file = tempfile.NamedTemporaryFile(delete=False)
-                nvs_file.write(b'\xff' * size)
-                if not isinstance(address, int):
-                    address = int(address, 0)
-
-                if self.app.flash_settings['encrypt']:
-                    encrypt_files.append((address, open(nvs_file.name, 'rb')))
+        _args = []
+        for k, v in self.app.flash_args['extra_esptool_args'].items():
+            if isinstance(v, bool):
+                if k == 'stub':
+                    if v is False:
+                        _args.append('--no-stub')
+                elif v:
+                    _args.append(f'--{k}')
+            else:
+                _args.append(f'--{k}')
+                if k == 'after':
+                    _args.append('hard_reset')
                 else:
-                    flash_files.append((address, open(nvs_file.name, 'rb')))
+                    _args.append(str(v))
 
-            # write_flash expects the parameter encrypt_files to be None and not
-            # an empty list, so perform the check here
-            default_kwargs = {
-                'addr_filename': flash_files,
-                'encrypt_files': encrypt_files or None,
-                'no_stub': False,
-                'compress': True,
-                'verify': False,
-                'ignore_flash_encryption_efuse_setting': False,
-                'erase_all': False,
-                'force': False,
-            }
+        _args.append('write_flash')
 
-            default_kwargs.update(self.app.flash_settings)
-            default_kwargs.update(self.app.flash_args.get('extra_esptool_args', {}))
-            args = EsptoolArgs(**default_kwargs)
+        if self.erase_nvs:
+            esptool.main(
+                [
+                    'erase_region',
+                    str(self.app.partition_table['nvs']['offset']),
+                    str(self.app.partition_table['nvs']['size']),
+                ],
+                esp=self.esp,
+            )
+            self.esp.connect()
 
-            self.stub.change_baud(self.esptool_baud)
-            esptool.detect_flash_size(self.stub, args)
-            esptool.write_flash(self.stub, args)
-            self.stub.change_baud(self.baud)
+        encrypt_files = []
+        flash_files = []
+        for file in self.app.flash_files:
+            if file.encrypted:
+                encrypt_files.append(hex(file.offset))
+                encrypt_files.append(str(file.file_path))
+            else:
+                flash_files.append(hex(file.offset))
+                flash_files.append(file.file_path)
 
-            if self._meta:
-                self._meta.set_port_app_cache(self.port, self.app)
-        finally:
-            if nvs_file:
-                nvs_file.close()
-                try:
-                    os.remove(nvs_file.name)
-                except OSError:
-                    pass
-            for _, f in flash_files:
-                f.close()
-            for _, f in encrypt_files:
-                f.close()
+        if flash_files and encrypt_files:
+            _args.extend(flash_files)
+            _args.append('--encrypt-files')
+            _args.extend(encrypt_files)
+        else:
+            if flash_files:
+                _args.extend(flash_files)
+            else:
+                _args.append('--encrypt')
+                _args.extend(encrypt_files)
+
+        _args.extend(self.app.flash_args['write_flash_args'])
+        _args.extend(self._force_flag())
+
+        esptool.main(_args, esp=self.esp)
+
+        if self._meta:
+            self._meta.set_port_app_cache(self.port, self.app)
 
     @EspSerial.use_esptool()
     def dump_flash(
@@ -207,15 +215,12 @@ class IdfSerial(EspSerial):
         else:
             raise ValueError('You must specify "partition" or ("address" and "size") to dump flash')
 
-        content = self.stub.read_flash(_addr, _size)
         if output:
-            if isinstance(output, str):
-                os.makedirs(os.path.dirname(output), exist_ok=True)
-                with open(output, 'wb') as f:
-                    f.write(content)
-            else:
-                output.write(content)
+            esptool.main(['read_flash', str(_addr), str(_size), str(output)], esp=self.esp)
         else:
+            with tempfile.NamedTemporaryFile() as fp:
+                esptool.main(['read_flash', str(_addr), str(_size), fp.name], esp=self.esp)
+                content = fp.read()
             return content
 
     @EspSerial.use_esptool()
@@ -233,7 +238,7 @@ class IdfSerial(EspSerial):
             address = self.app.partition_table[partition_name]['offset']
             size = self.app.partition_table[partition_name]['size']
             logging.info(f'Erasing the partition "{partition_name}" of size {size} at {address}')
-            self.stub.erase_region(address, size)
+            esptool.main(['erase_region', str(address), str(size), *self._force_flag()], esp=self.esp)
         else:
             raise ValueError(f'partition name "{partition_name}" not found in app partition table')
 
@@ -254,7 +259,13 @@ class IdfSerial(EspSerial):
         if not bin_offset:
             raise ValueError('.bin file not found in flash files')
 
-        return self.stub.read_flash(bin_offset + self.DEFAULT_SHA256_OFFSET, 32)
+        with tempfile.NamedTemporaryFile() as fp:
+            esptool.main(
+                ['read_flash', str(bin_offset + self.DEFAULT_SHA256_OFFSET), str(32), fp.name],
+                esp=self.esp,
+            )
+            content = fp.read()
+        return content
 
     def is_target_flashed_same_elf(self) -> bool:
         """

--- a/pytest-embedded-idf/tests/test_idf.py
+++ b/pytest-embedded-idf/tests/test_idf.py
@@ -35,6 +35,43 @@ def test_idf_serial_flash(testdir):
     result.assert_outcomes(passed=1)
 
 
+def test_esp_flash_force_flag(testdir):
+    testdir.makepyfile("""
+        import pexpect
+        import pytest
+
+        def test_idf_serial_flash(dut):
+            dut.expect('Hello world!')
+            assert dut.serial.esp_flash_force == True
+    """)
+    result = testdir.runpytest(
+        '-s',
+        '--embedded-services', 'esp,idf',
+        '--app-path', os.path.join(testdir.tmpdir, 'hello_world_esp32'),
+        '--esp-flash-force',
+    )
+
+    result.assert_outcomes(passed=1)
+
+
+def test_esp_flash_no_force_flag(testdir):
+    testdir.makepyfile("""
+        import pexpect
+        import pytest
+
+        def test_idf_serial_flash(dut):
+            dut.expect('Hello world!')
+            assert dut.serial.esp_flash_force == False
+    """)
+    result = testdir.runpytest(
+        '-s',
+        '--embedded-services', 'esp,idf',
+        '--app-path', os.path.join(testdir.tmpdir, 'hello_world_esp32'),
+    )
+
+    result.assert_outcomes(passed=1)
+
+
 def test_expect_no_matching(testdir):
     testdir.makepyfile("""
         import pexpect

--- a/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
+++ b/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
@@ -55,6 +55,7 @@ class EspSerial(Serial):
         port_mac: str = None,
         baud: int = Serial.DEFAULT_BAUDRATE,
         esptool_baud: int = ESPTOOL_DEFAULT_BAUDRATE,
+        esp_flash_force: bool = False,
         skip_autoflash: bool = False,
         erase_all: bool = False,
         meta: Optional[Meta] = None,
@@ -119,6 +120,7 @@ class EspSerial(Serial):
         self.skip_autoflash = skip_autoflash
         self.erase_all = erase_all
         self.esptool_baud = esptool_baud
+        self.esp_flash_force = esp_flash_force
 
         super().__init__(msg_queue=msg_queue, port=self.esp._port, baud=baud, meta=meta, **kwargs)
 
@@ -175,7 +177,11 @@ class EspSerial(Serial):
     def erase_flash(self):
         """Erase the complete flash"""
         logging.info('Erasing the flash')
-        esptool.main(['erase_flash', '--force'], esp=self.esp)
+        options = ['erase_flash']
+        if self.esp_flash_force:
+            options.append('--force')
+
+        esptool.main(options, esp=self.esp)
 
         if self._meta:
             self._meta.drop_port_app_cache(self.port)

--- a/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
+++ b/pytest-embedded-serial-esp/pytest_embedded_serial_esp/serial.py
@@ -3,11 +3,10 @@ import functools
 import logging
 import subprocess
 from typing import Optional
+from warnings import warn
 
 import esptool
-from esptool import CHIP_DEFS, FatalError
 from esptool import __version__ as ESPTOOL_VERSION
-from esptool import detect_chip
 from esptool.targets import CHIP_LIST as ESPTOOL_CHIPS
 from pexpect import TIMEOUT
 from pytest_embedded.log import MessageQueue, PexpectProcess, live_print_call
@@ -101,47 +100,19 @@ class EspSerial(Serial):
             )
 
         with contextlib.redirect_stdout(msg_queue):
-            # Temp workaround for esptool
-            # on windows have to close the unused scanned ports manually
-            #
-            # could revert to the following code blocks after fixing it
-            #
-            # esp: esptool.ESPLoader = esptool.get_default_connected_device(
-            #     ports,
-            #     port=port,
-            #     connect_attempts=3,
-            #     initial_baud=baud,
-            #     chip=esptool_target,
-            # )
-            _esp = None
-            for each_port in reversed(ports):
-                print(f'Serial port {each_port}')
-                try:
-                    if esptool_target == 'auto':
-                        _esp = detect_chip(each_port, baud, connect_attempts=3)
-                    else:
-                        chip_class = CHIP_DEFS[esptool_target]
-                        _esp = chip_class(each_port, baud)
-                        _esp.connect(attempts=3)
-                    break
-                except (FatalError, OSError) as err:
-                    if port is not None:
-                        raise
-                    print(f'{each_port} failed to connect: {err}')
-                    if _esp:
-                        # ensure unused port is closed.
-                        _esp._port.close()
-                    _esp = None
-            esp = _esp
+            self.esp = esptool.get_default_connected_device(
+                ports,
+                port=port,
+                connect_attempts=3,
+                initial_baud=baud,
+                chip=esptool_target,
+            )
 
-        if not esp:
+        if not self.esp:
             raise ValueError('Couldn\'t auto detect chip. Please manually specify with "--port"')
 
-        self.esp: esptool.ESPLoader = None  # type: ignore
-        self.stub: esptool.ESPLoader = None  # type: ignore
-
-        target = esp.CHIP_NAME.lower().replace('-', '')
-        logging.info('Target: %s, Port: %s', target, esp.serial_port)
+        target = self.esp.CHIP_NAME.lower().replace('-', '')
+        logging.info('Target: %s, Port: %s', target, self.esp.serial_port)
 
         self.target = target
 
@@ -149,14 +120,14 @@ class EspSerial(Serial):
         self.erase_all = erase_all
         self.esptool_baud = esptool_baud
 
-        super().__init__(msg_queue=msg_queue, port=esp._port, baud=baud, meta=meta, **kwargs)
+        super().__init__(msg_queue=msg_queue, port=self.esp._port, baud=baud, meta=meta, **kwargs)
 
     def _post_init(self):
         if self._meta:
             self._meta.set_port_target_cache(self.port, self.target)
 
         if self.erase_all:
-            self.erase_flash()
+            esptool.main(['erase_flash'], esp=self.esp)
 
         super()._post_init()
 
@@ -172,6 +143,11 @@ class EspSerial(Serial):
             hard_reset_after: run hard reset after
             no_stub: disable launching the flasher stub
         """
+        warn(
+            "The 'no_stub' parameter is now read directly from `flasher_args.json` "
+            'and does not need to be explicitly set.',
+            DeprecationWarning,
+        )
 
         def decorator(func):
             @functools.wraps(func)
@@ -179,20 +155,9 @@ class EspSerial(Serial):
                 with self.disable_redirect_thread():
                     with contextlib.redirect_stdout(self._q):
                         settings = self.proc.get_settings()
-                        try:
-                            self.esp = esptool.detect_chip(self.proc, self.baud)
-                            self.esp.connect('hard_reset')
-
-                            if not no_stub:
-                                self.stub = self.esp.run_stub()
-
-                            ret = func(self, *args, **kwargs)
-                        finally:
-                            if hard_reset_after:
-                                self.esp.hard_reset()
-
-                            self.proc.apply_settings(settings)
-
+                        self.esp.connect()
+                        ret = func(self, *args, **kwargs)
+                        self.proc.apply_settings(settings)
                 return ret
 
             return wrapper
@@ -202,16 +167,23 @@ class EspSerial(Serial):
     def _start(self):
         self.hard_reset()
 
-    @use_esptool(hard_reset_after=True, no_stub=True)
     def hard_reset(self):
         """Hard reset your espressif device"""
-        pass
+        self.esp.hard_reset()
 
     @use_esptool()
     def erase_flash(self):
         """Erase the complete flash"""
         logging.info('Erasing the flash')
-        self.stub.erase_flash()
+        esptool.main(['erase_flash', '--force'], esp=self.esp)
 
         if self._meta:
             self._meta.drop_port_app_cache(self.port)
+
+    @property
+    def stub(self):
+        warn(
+            'Please use `self.esp` instead of `self.stub`. `self.stub` will be removed in 2.0 release.',
+            DeprecationWarning,
+        )
+        return self.esp

--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -164,7 +164,11 @@ def pytest_addoption(parser):
         '--port-mac',
         help='MAC address of the board. (Default: None)',
     )
-
+    esp_group.addoption(
+        '--esp-flash-force',
+        action='store_true',
+        help='force mode for esptool',
+    )
     idf_group = parser.getgroup('embedded-idf')
     idf_group.addoption(
         '--part-tool',
@@ -767,6 +771,13 @@ def app_path(request: FixtureRequest, test_file_path: str) -> t.Optional[str]:
 
 @pytest.fixture
 @multi_dut_argument
+def esp_flash_force(request: FixtureRequest) -> t.Optional[str]:
+    """Enable parametrization for the same cli option"""
+    return _request_param_or_config_option_or_default(request, 'esp_flash_force', False)
+
+
+@pytest.fixture
+@multi_dut_argument
 def build_dir(request: FixtureRequest) -> t.Optional[str]:
     """Enable parametrization for the same cli option"""
     return _request_param_or_config_option_or_default(request, 'build_dir', 'build')
@@ -1024,6 +1035,7 @@ def _fixture_classes_and_options(
     skip_autoflash,
     erase_all,
     esptool_baud,
+    esp_flash_force,
     part_tool,
     confirm_target_elf_sha256,
     erase_nvs,
@@ -1122,6 +1134,7 @@ def _fixture_classes_and_options(
                     'port_mac': port_mac,
                     'baud': int(baud or EspSerial.DEFAULT_BAUDRATE),
                     'esptool_baud': int(os.getenv('ESPBAUD') or esptool_baud or EspSerial.ESPTOOL_DEFAULT_BAUDRATE),
+                    'esp_flash_force': esp_flash_force,
                     'skip_autoflash': skip_autoflash,
                     'erase_all': erase_all,
                     'meta': _meta,


### PR DESCRIPTION
- This PR replaced the use of the esptool functions with `esptool.main`.
- Added the flag '--esp-flash-force' for 'force mode for esptool'.

closes #235 