### PR TITLE
feat: gdb panic server from module (RDT-606)

### DIFF
--- a/pytest-embedded-idf/pyproject.toml
+++ b/pytest-embedded-idf/pyproject.toml
@@ -30,6 +30,7 @@ requires-python = ">=3.7"
 
 dependencies = [
     "pytest-embedded~=1.4.2",
+    "esp-idf-panic-decoder",
 ]
 
 [project.optional-dependencies]

--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -193,7 +193,7 @@ def pytest_addoption(parser):
     idf_group.addoption(
         '--panic-output-decode-script',
         help='Panic output decode script that is used in conjunction with the check-panic-coredump option '
-        'to parse panic output. (Default: $IDF_PATH/tools/gdb_panic_server.py)',
+        'to parse panic output. (Default: use gdb_panic_server.py from package esp_idf_panic_decoder)',
     )
 
     jtag_group = parser.getgroup('embedded-jtag')


### PR DESCRIPTION
Import `gdb_panic_server.py from esp_idf_panic_decoder` and use it instead of the static `$IDF_PATH/tools/gdb_panic_server.py` path.
closes #225 