### PR TITLE
fix(qemu): fix qmp client missing event loop in main thread

### DIFF
--- a/pytest-embedded-qemu/pytest_embedded_qemu/qemu.py
+++ b/pytest-embedded-qemu/pytest_embedded_qemu/qemu.py
@@ -61,7 +61,6 @@ class Qemu(DuplicateStdoutPopen):
 
         self.qmp_addr = None
         self.qmp_port = None
-        self.qmp = QMPClient()
 
         dut_index = int(kwargs.pop('dut_index', 0))
         for i, v in enumerate(qemu_cli_args):
@@ -110,11 +109,13 @@ class Qemu(DuplicateStdoutPopen):
 
         async def h_r():
             nonlocal response
+
+            qmp = QMPClient()
             try:
-                await self.qmp.connect((str(self.qmp_addr), int(self.qmp_port)))
-                response = await self.qmp.execute(execute, arguments=arguments)
+                await qmp.connect((str(self.qmp_addr), int(self.qmp_port)))
+                response = await qmp.execute(execute, arguments=arguments)
             finally:
-                await self.qmp.disconnect()
+                await qmp.disconnect()
 
         asyncio.run(h_r())
         return response


### PR DESCRIPTION
In CI tested internally, we're facing errors like

```
/root/.espressif/python_env/idf5.3_py3.8_env/lib/python3.8/site-packages/pytest_embedded/plugin.py:458: in wrapper
    res = func(*args, **kwargs)
/root/.espressif/python_env/idf5.3_py3.8_env/lib/python3.8/site-packages/pytest_embedded/plugin.py:1379: in qemu
    return cls(**_drop_none_kwargs(kwargs))
/root/.espressif/python_env/idf5.3_py3.8_env/lib/python3.8/site-packages/pytest_embedded_qemu/qemu.py:64: in __init__
    self.qmp = QMPClient()
/root/.espressif/python_env/idf5.3_py3.8_env/lib/python3.8/site-packages/qemu/qmp/qmp_client.py:247: in __init__
    Events.__init__(self)
/root/.espressif/python_env/idf5.3_py3.8_env/lib/python3.8/site-packages/qemu/qmp/events.py:656: in __init__
    self.events: EventListener = EventListener()
/root/.espressif/python_env/idf5.3_py3.8_env/lib/python3.8/site-packages/qemu/qmp/events.py:504: in __init__
    self._queue: 'asyncio.Queue[Message]' = asyncio.Queue()
/usr/lib/python3.8/asyncio/queues.py:35: in __init__
    self._loop = events.get_event_loop()
/usr/lib/python3.8/asyncio/events.py:639: in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
E   RuntimeError: There is no current event loop in thread 'MainThread'.
```

Tested locally not reproducible with python 3.8 nor python 3.12
