### PR TITLE
feature: Preliminary esp32p4 support in Wokwi

### DIFF
--- a/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
+++ b/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
@@ -19,6 +19,7 @@ target_to_board = {
     'esp32c3': 'board-esp32-c3-devkitm-1',
     'esp32c6': 'board-esp32-c6-devkitc-1',
     'esp32h2': 'board-esp32-h2-devkitm-1',
+    'esp32p4': 'board-esp32-p4-preview',
     'esp32s2': 'board-esp32-s2-devkitm-1',
     'esp32s3': 'board-esp32-s3-devkitc-1',
 }


### PR DESCRIPTION
We now have ESP32-P4 support in Wokwi!

It is still a preview release, but it's functional enough to run tests. I ran a quick test on my system, here is the complete output:

```
(pytest-new) PS C:\p\wokwi-esp-test-template\test_app> pytest --target=esp32p4 --embedded-services idf,wokwi
============================================== test session starts ===============================================
platform win32 -- Python 3.8.10, pytest-7.4.4, pluggy-1.3.0
rootdir: C:\p\wokwi-esp-test-template\test_app
configfile: pytest.ini
plugins: embedded-1.6.1
collected 1 item

test_app.py::test_app
------------------------------------------------- live log setup ------------------------------------------------- 
2024-01-11 00:32:42 INFO Executing wokwi-cli C:\p\wokwi-esp-test-template\test_app
2024-01-11 00:32:42 Wokwi CLI v0.8.0 (2a4bae54982c)
2024-01-11 00:32:43 Connected to Wokwi Simulation API 1.0.0-20240111-g887148e6
2024-01-11 00:32:45 Starting simulation...
2024-01-11 00:32:46 ESP-ROM:esp32p4-20230811
2024-01-11 00:32:46 Build:Aug 11 2023
2024-01-11 00:32:46
2024-01-11 00:32:46 rst:0x1 (POWERON),boot:0x8 (SPI_FAST_FLASH_BOOT)
2024-01-11 00:32:46 SPI mode:DIO, clock div:1
2024-01-11 00:32:46 load:0x4ff2bbd0,len:0xa30
2024-01-11 00:32:46 load:0x4ff2dbd0,len:0x2d6c
2024-01-11 00:32:46 load:0x4ff34ce0,len:0x1848
2024-01-11 00:32:46
2024-01-11 00:32:46 SHA-256 comparison failed:
2024-01-11 00:32:46 Calculated: 79168065e13b3bf30c0def7962ae69dc1fb103c8fc6e8fa158c2dac7904bd22c
2024-01-11 00:32:46
2024-01-11 00:32:46 Expected: a9f33802bdb0efa871d958f6bff8166c16fa8cfadb1120a10644ccb183779503
2024-01-11 00:32:46 Attempting to boot anyway...
2024-01-11 00:32:46 entry 0x4ff2bbdc
2024-01-11 00:32:46 I (14) boot: ESP-IDF v5.3-dev-1353-gb3f7e2c8a4 2nd stage bootloader
2024-01-11 00:32:46 I (14) boot: compile time Jan 10 2024 23:20:03
2024-01-11 00:32:46 I (15) boot: Multicore bootloader
2024-01-11 00:32:46 I (16) boot: chip revision: v0.0
2024-01-11 00:32:46 I (17) boot.esp32p4: SPI Speed      : 80MHz
2024-01-11 00:32:46 I (19) boot.esp32p4: SPI Mode       : DIO
2024-01-11 00:32:46 I (20) boot.esp32p4: SPI Flash Size : 4MB
2024-01-11 00:32:46 I (22) boot: Enabling RNG early entropy source...
2024-01-11 00:32:46 W (24) bootloader_random: bootloader_random_enable() has not been implemented yet
2024-01-11 00:32:46 I (27) boot: Partition Table:
2024-01-11 00:32:46 I (28) boot: ## Label            Usage          Type ST Offset   Length
2024-01-11 00:32:46
2024-01-11 00:32:46 I (31) boot:  0 nvs              WiFi data        01 02 00009000 00006000
2024-01-11 00:32:46 I (33) boot:  1 phy_init         RF data          01 01 0000f000 00001000
2024-01-11 00:32:46 I (36) boot:  2 factory          factory app      00 00 00010000 00100000
2024-01-11 00:32:47
2024-01-11 00:32:47 I (39) boot: End of partition table
2024-01-11 00:32:47 I (40) esp_image: segment 0: paddr=00010020 vaddr=40020020 size=0a1e8h ( 41448) map
2024-01-11 00:32:47 E (43) fpga_rng: Project configuration is for internal FPGA use, RNG will not work
2024-01-11 00:32:47 I (52) esp_image: segment 1: paddr=0001a210 vaddr=4ff00000 size=05e08h ( 24072) load
2024-01-11 00:32:47 I (58) esp_image: segment 2: paddr=00020020 vaddr=40000020 size=152ach ( 86700) map
2024-01-11 00:32:47 I (71) esp_image: segment 3: paddr=000352d4 vaddr=4ff05e08 size=06014h ( 24596) load
2024-01-11 00:32:47 I (76) esp_image: segment 4: paddr=0003b2f0 vaddr=4ff0be20 size=012c8h (  4808) load
2024-01-11 00:32:47 I (82) boot: Loaded app from partition at offset 0x10000
2024-01-11 00:32:47 I (82) boot: Disabling RNG early entropy source...
2024-01-11 00:32:47 W (83) bootloader_random: bootloader_random_enable() has not been implemented yet
2024-01-11 00:32:47 I (89) cpu_start: Multicore app
2024-01-11 00:32:47 W (24) clk: esp_perip_clk_init() has not been implemented yet
2024-01-11 00:32:47 I (25) cpu_start: Pro cpu start user code
2024-01-11 00:32:47 I (25) cpu_start: cpu freq: 360000000 Hz
2024-01-11 00:32:47 I (25) cpu_start: Application information:
2024-01-11 00:32:47
2024-01-11 00:32:47 I (25) cpu_start: Project name:     example_test_app
2024-01-11 00:32:47 I (25) cpu_start: App version:      681415e-dirty
2024-01-11 00:32:47 I (26) cpu_start: Compile time:     Jan 10 2024 23:19:46
2024-01-11 00:32:47 I (26) cpu_start: ELF file SHA256:  e35b0654c...
2024-01-11 00:32:47 I (27) cpu_start: ESP-IDF:          v5.3-dev-1353-gb3f7e2c8a4
2024-01-11 00:32:47 I (27) cpu_start: Min chip rev:     v0.0
2024-01-11 00:32:47 I (28) cpu_start: Max chip rev:     v0.99 
2024-01-11 00:32:47 I (28) cpu_start: Chip rev:         v0.0
2024-01-11 00:32:47 I (29) heap_init: Initializing. RAM available for dynamic allocation:
2024-01-11 00:32:47 I (29) heap_init: At 4FF0EA10 len 0002C5B0 (177 KiB): RAM
2024-01-11 00:32:47 I (30) heap_init: At 4FF3AFC0 len 00004BE4 (18 KiB): RAM
2024-01-11 00:32:47 I (30) heap_init: At 4FF40000 len 00060000 (384 KiB): RAM
2024-01-11 00:32:47 I (31) heap_init: At 50108000 len 00007FE8 (31 KiB): RTCRAM
2024-01-11 00:32:47 I (31) heap_init: At 30100000 len 00002000 (8 KiB): TCM
2024-01-11 00:32:47 I (32) spi_flash: detected chip: generic
2024-01-11 00:32:47 I (32) spi_flash: flash io: dio
2024-01-11 00:32:47 I (33) main_task: Started on CPU0
2024-01-11 00:32:47 I (43) main_task: Calling app_main()
2024-01-11 00:32:47 Unity test run 1 of 1
2024-01-11 00:32:47 TEST(testable, mean_of_empty) PASS
2024-01-11 00:32:47 TEST(testable, mean_of_vector) PASS
2024-01-11 00:32:48 IGNORE_TEST(testable, test_fail)
2024-01-11 00:32:48
2024-01-11 00:32:48 -----------------------
2024-01-11 00:32:48 3 Tests 0 Failures 1 Ignored
2024-01-11 00:32:48 OK
2024-01-11 00:32:48
2024-01-11 00:32:48 Tests finished, rc=0
2024-01-11 00:32:48 I (93) main_task: Returned from app_main()
2024-01-11 00:32:48
PASSED
----------------------------------------------- live log teardown ------------------------------------------------ 
2024-01-11 00:32:48 INFO Created unity output junit report: C:\Users\Uri\AppData\Local\Temp\pytest-embedded\2024-01-10_22-32-42-662691\test_app\dut.xml


=============================================== 1 passed in 5.43s ================================================ 
```