### PR TITLE
fix: use socket bind to get allowed port

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -39,7 +39,7 @@ jobs:
           apt update && apt install -y socat zip
           pip install -U pip
           export PIP_EXTRA_INDEX_URL="https://dl.espressif.com/pypi"
-          pip install cryptography --only-binary :all:
+          pip install cryptography --prefer-binary
           pip install -r requirements.txt
           bash foreach.sh install
       - name: Check ports

--- a/pytest-embedded-qemu/tests/test_qemu.py
+++ b/pytest-embedded-qemu/tests/test_qemu.py
@@ -53,7 +53,7 @@ def test_pexpect_make_restart_by_qemu_xtensa(testdir):
         '-s',
         '--embedded-services', 'idf,qemu',
         '--app-path', os.path.join(testdir.tmpdir, 'hello_world_esp32'),
-        '--qemu-cli-args="-qmp tcp:localhost:4488,server,wait=off -machine esp32 -nographic"',
+        '--qemu-cli-args="-machine esp32 -nographic"',
     )
 
     result.assert_outcomes(passed=1)


### PR DESCRIPTION
While running the test, we encountered a conflict with port allocation. The current PR is an attempt to resolve this issue.