### PR TITLE
fix(wokwi): run in interactive mode

### DIFF
--- a/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
+++ b/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
@@ -54,7 +54,7 @@ class WokwiCLI(DuplicateStdoutPopen):
         wokwi_cli = wokwi_cli_path or self.wokwi_cli_executable
 
         super().__init__(
-            cmd=[wokwi_cli, app.app_path],
+            cmd=[wokwi_cli, '--interactive', app.app_path],
             **kwargs,
         )
 


### PR DESCRIPTION
see https://github.com/espressif/pytest-embedded/issues/233#issuecomment-1893741907 for details.

Note: this fix requires updating wokwi-cli to the latest version, 0.9.0. For people using this in CI, the latest version should be installed automatically. 