### PR TITLE
fix: flash baud

### DIFF
--- a/pytest-embedded-idf/pytest_embedded_idf/serial.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/serial.py
@@ -1,6 +1,7 @@
 import contextlib
 import hashlib
 import logging
+import os
 import tempfile
 from typing import Optional, TextIO, Union
 
@@ -161,6 +162,8 @@ class IdfSerial(EspSerial):
                 else:
                     _args.append(str(v))
 
+        if '--baud' not in _args:
+            _args.extend(['--baud', os.getenv('ESPBAUD', '1000000')])
         _args.append('write_flash')
 
         if self.erase_nvs:


### PR DESCRIPTION
Set the baud rate to 1,000,000 to make the flash faster when no value is set up. 
Closes #268.