### PR TITLE
feat(wokwi): Add scenario path parameter

### DIFF
--- a/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
+++ b/pytest-embedded-wokwi/pytest_embedded_wokwi/wokwi_cli.py
@@ -40,6 +40,7 @@ class WokwiCLI(DuplicateStdoutPopen):
         firmware_resolver: IDFFirmwareResolver,
         wokwi_cli_path: t.Optional[str] = None,
         wokwi_timeout: t.Optional[int] = None,
+        wokwi_scenario: t.Optional[str] = None,
         app: t.Optional['IdfApp'] = None,
         **kwargs,
     ):
@@ -57,6 +58,8 @@ class WokwiCLI(DuplicateStdoutPopen):
         cmd = [wokwi_cli, '--interactive', app.app_path]
         if (wokwi_timeout is not None) and (wokwi_timeout > 0):
             cmd.extend(['--timeout', str(wokwi_timeout)])
+        if (wokwi_scenario is not None) and os.path.exists(wokwi_scenario):
+            cmd.extend(['--scenario', wokwi_scenario])
 
         super().__init__(
             cmd=cmd,

--- a/pytest-embedded/pytest_embedded/dut_factory.py
+++ b/pytest-embedded/pytest_embedded/dut_factory.py
@@ -147,6 +147,7 @@ def _fixture_classes_and_options_fn(
     qemu_extra_args,
     wokwi_cli_path,
     wokwi_timeout,
+    wokwi_scenario,
     skip_regenerate_image,
     encrypt,
     keyfile,
@@ -298,6 +299,7 @@ def _fixture_classes_and_options_fn(
                 kwargs[fixture].update({
                     'wokwi_cli_path': wokwi_cli_path,
                     'wokwi_timeout': wokwi_timeout,
+                    'wokwi_scenario': wokwi_scenario,
                     'msg_queue': msg_queue,
                     'app': None,
                     'meta': _meta,
@@ -603,6 +605,7 @@ class DutFactory:
         qemu_extra_args: t.Optional[str] = None,
         wokwi_cli_path: t.Optional[str] = None,
         wokwi_timeout: t.Optional[int] = 0,
+        wokwi_scenario: t.Optional[str] = None,
         skip_regenerate_image: t.Optional[bool] = None,
         encrypt: t.Optional[bool] = None,
         keyfile: t.Optional[str] = None,
@@ -648,6 +651,7 @@ class DutFactory:
         - qemu_extra_args: Additional QEMU arguments.
         - wokwi_cli_path: Wokwi CLI path.
         - wokwi_timeout: Wokwi timeout.
+        - wokwi_scenario: Wokwi scenario path.
         - skip_regenerate_image: Skip image regeneration flag.
         - encrypt: Encryption flag.
         - keyfile: Keyfile for encryption.
@@ -709,6 +713,7 @@ class DutFactory:
                 'qemu_extra_args': qemu_extra_args,
                 'wokwi_cli_path': wokwi_cli_path,
                 'wokwi_timeout': wokwi_timeout,
+                'wokwi_scenario': wokwi_scenario,
                 'skip_regenerate_image': skip_regenerate_image,
                 'encrypt': encrypt,
                 'keyfile': keyfile,

--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -273,6 +273,10 @@ def pytest_addoption(parser):
         type=_gte_one_int,
         help='Simulation timeout in milliseconds (Default: 86400000)',
     )
+    wokwi_group.addoption(
+        '--wokwi-scenario',
+        help='Path to the wokwi scenario file (Default: None)',
+    )
 
 
 ###########
@@ -947,6 +951,13 @@ def wokwi_timeout(request: FixtureRequest) -> t.Optional[str]:
     return _request_param_or_config_option_or_default(request, 'wokwi_timeout', None)
 
 
+@pytest.fixture
+@multi_dut_argument
+def wokwi_scenario(request: FixtureRequest) -> t.Optional[str]:
+    """Enable parametrization for the same cli option"""
+    return _request_param_or_config_option_or_default(request, 'wokwi_scenario', None)
+
+
 ####################
 # Private Fixtures #
 ####################
@@ -1003,6 +1014,7 @@ def parametrize_fixtures(
     qemu_extra_args,
     wokwi_cli_path,
     wokwi_timeout,
+    wokwi_scenario,
     skip_regenerate_image,
     encrypt,
     keyfile,


### PR DESCRIPTION
This PR adds a support of scenario file for Pytest-wokwi.
To use scenario file add `--wokwi_scenario <path>` to the pytest command