### PR TITLE
feat: dry run single board unity test

### DIFF
--- a/pytest-embedded-idf/tests/test_idf.py
+++ b/pytest-embedded-idf/tests/test_idf.py
@@ -682,6 +682,70 @@ def test_idf_multi_hard_reset_and_expect(testdir):
     result.assert_outcomes(passed=1)
 
 
+def test_select_to_run():
+    from pytest_embedded_idf.unity_tester import IdfUnityDutMixin
+
+    assert IdfUnityDutMixin._select_to_run(
+        None, None, None,
+        None, None, None
+    )
+
+    assert IdfUnityDutMixin._select_to_run(
+        None, ['name_hello', 'name_world'], None,
+        None, 'name_hello', None
+    )
+
+    assert not IdfUnityDutMixin._select_to_run(
+        None, ['name_hello', 'name_world'], None,
+        None, 'name_hel', None
+    )
+
+    assert IdfUnityDutMixin._select_to_run(
+        None, None, {"red": 255},
+        None, None, {"red": 255, "green": 10, "blue": 33}
+    )
+
+    assert not IdfUnityDutMixin._select_to_run(
+        None, None, {"red": 25},
+        None, None, {"red": 255, "green": 10, "blue": 33}
+    )
+
+    assert IdfUnityDutMixin._select_to_run(
+        None, None, {"red": 255, "green": 10},
+        None, None, {"red": 255, "green": 10, "blue": 33}
+    )
+
+    assert not IdfUnityDutMixin._select_to_run(
+        None, None, {"red": 255, "green": 0},
+        None, None, {"red": 255, "green": 10, "blue": 33}
+    )
+
+    assert IdfUnityDutMixin._select_to_run(
+        [['hello']], None, None,
+        ['hello', 'world'], None, None
+    )
+
+    assert not IdfUnityDutMixin._select_to_run(
+        [['!hello']], None, None,
+        ['hello', 'world'], None, None
+    )
+
+    assert not IdfUnityDutMixin._select_to_run(
+        [['hello', '!world']], None, None,
+        ['hello', 'world'], None, None
+    )
+
+    assert IdfUnityDutMixin._select_to_run(
+        [['hello', '!world'], ['sun']], None, None,
+        ['hello', 'world', 'sun'], None, None
+    )
+
+    assert IdfUnityDutMixin._select_to_run(
+        [['hello', '!w']], None, None,
+        ['hello', 'world'], None, None
+    )
+
+
 def test_dut_run_all_single_board_cases(testdir):
     testdir.makepyfile(r"""
         def test_dut_run_all_single_board_cases(dut):


### PR DESCRIPTION
This MR implements a feature for dry running single board Unity tests, allowing users to display a list of test case names without actually running them when the `dry_run` parameter in `run_all_single_board_cases` is set to True.