### PR TITLE
feat(wokwi): Add support for specifying diagram path

### DIFF
--- a/pytest-embedded-wokwi/pytest_embedded_wokwi/__init__.py
+++ b/pytest-embedded-wokwi/pytest_embedded_wokwi/__init__.py
@@ -1,9 +1,12 @@
 """Make pytest-embedded plugin work with the Wokwi CLI."""
 
-from .dut import WokwiDut
-from .wokwi_cli import WokwiCLI
+WOKWI_CLI_MINIMUM_VERSION = '0.10.1'
+
+from .dut import WokwiDut  # noqa
+from .wokwi_cli import WokwiCLI  # noqa
 
 __all__ = [
+    'WOKWI_CLI_MINIMUM_VERSION',
     'WokwiCLI',
     'WokwiDut',
 ]

--- a/pytest-embedded-wokwi/tests/test_wokwi.py
+++ b/pytest-embedded-wokwi/tests/test_wokwi.py
@@ -54,6 +54,7 @@ def test_pexpect_by_wokwi_esp32_arduino(testdir):
         '-s',
         '--embedded-services', 'arduino,wokwi',
         '--app-path', os.path.join(testdir.tmpdir, 'hello_world_arduino'),
+        '--wokwi-diagram', os.path.join(testdir.tmpdir, 'hello_world_arduino/esp32.diagram.json'),
     )
 
     result.assert_outcomes(passed=1)

--- a/pytest-embedded/pytest_embedded/dut_factory.py
+++ b/pytest-embedded/pytest_embedded/dut_factory.py
@@ -149,6 +149,7 @@ def _fixture_classes_and_options_fn(
     wokwi_cli_path,
     wokwi_timeout,
     wokwi_scenario,
+    wokwi_diagram,
     skip_regenerate_image,
     encrypt,
     keyfile,
@@ -302,6 +303,7 @@ def _fixture_classes_and_options_fn(
                     'wokwi_cli_path': wokwi_cli_path,
                     'wokwi_timeout': wokwi_timeout,
                     'wokwi_scenario': wokwi_scenario,
+                    'wokwi_diagram': wokwi_diagram,
                     'msg_queue': msg_queue,
                     'app': None,
                     'meta': _meta,
@@ -608,6 +610,7 @@ class DutFactory:
         wokwi_cli_path: t.Optional[str] = None,
         wokwi_timeout: t.Optional[int] = 0,
         wokwi_scenario: t.Optional[str] = None,
+        wokwi_diagram: t.Optional[str] = None,
         skip_regenerate_image: t.Optional[bool] = None,
         encrypt: t.Optional[bool] = None,
         keyfile: t.Optional[str] = None,
@@ -655,6 +658,7 @@ class DutFactory:
             wokwi_cli_path: Wokwi CLI path.
             wokwi_timeout: Wokwi timeout.
             wokwi_scenario: Wokwi scenario path.
+            wokwi_diagram: Wokwi diagram path.
             skip_regenerate_image: Skip image regeneration flag.
             encrypt: Encryption flag.
             keyfile: Keyfile for encryption.
@@ -718,6 +722,7 @@ class DutFactory:
                 'wokwi_cli_path': wokwi_cli_path,
                 'wokwi_timeout': wokwi_timeout,
                 'wokwi_scenario': wokwi_scenario,
+                'wokwi_diagram': wokwi_diagram,
                 'skip_regenerate_image': skip_regenerate_image,
                 'encrypt': encrypt,
                 'keyfile': keyfile,

--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -283,6 +283,10 @@ def pytest_addoption(parser):
         '--wokwi-scenario',
         help='Path to the wokwi scenario file (Default: None)',
     )
+    wokwi_group.addoption(
+        '--wokwi-diagram',
+        help='Path to the wokwi diagram file (Default: None)',
+    )
 
 
 ###########
@@ -973,6 +977,13 @@ def wokwi_scenario(request: FixtureRequest) -> t.Optional[str]:
     return _request_param_or_config_option_or_default(request, 'wokwi_scenario', None)
 
 
+@pytest.fixture
+@multi_dut_argument
+def wokwi_diagram(request: FixtureRequest) -> t.Optional[str]:
+    """Enable parametrization for the same cli option"""
+    return _request_param_or_config_option_or_default(request, 'wokwi_diagram', None)
+
+
 ####################
 # Private Fixtures #
 ####################
@@ -1031,6 +1042,7 @@ def parametrize_fixtures(
     wokwi_cli_path,
     wokwi_timeout,
     wokwi_scenario,
+    wokwi_diagram,
     skip_regenerate_image,
     encrypt,
     keyfile,


### PR DESCRIPTION
This PR adds a support of specifying diagram file for pytest-embedded-wokwi. 
To specify diagram.json add --wokwi-diagram to the pytest command