### PR TITLE
Revert "fix(jtag): gdb write "remotetimeout" stop waiting for response"

### DIFF
--- a/pytest-embedded-serial/pytest_embedded_serial/dut.py
+++ b/pytest-embedded-serial/pytest_embedded_serial/dut.py
@@ -44,5 +44,5 @@ class SerialDut(Dut):
 
     def setup_jtag(self):
         if self.gdb:
-            self.gdb.write('set remotetimeout 10', non_blocking=True)
+            self.gdb.write('set remotetimeout 10')
             self.gdb.write(f'target extended-remote :{self.openocd.gdb_port}')


### PR DESCRIPTION
This reverts commit fd1f21974c7c9e0c2ad1fd81b9c8a4e9650ebb26.