### PR TITLE
fix(wokwi): Use merged bin to ensure partition and bootloader flashing

### DIFF
--- a/pytest-embedded-wokwi/pytest_embedded_wokwi/arduino.py
+++ b/pytest-embedded-wokwi/pytest_embedded_wokwi/arduino.py
@@ -12,4 +12,4 @@ class ArduinoFirmwareResolver:
 
     def resolve_firmware(self, app: 'ArduinoApp'):
         # get path of ino.bin file
-        return Path(app.binary_path, app.sketch + '.ino.bin')
+        return Path(app.binary_path, app.sketch + '.ino.merged.bin')


### PR DESCRIPTION
## Description

Arduino tests in Wokwi will fallback to a default bootloader and partition table if none is provided. This can cause issues with some tests. To make sure the partition table and bootloader are always flashed, we need to use the generated merged image by the Arduino compilation.

## Testing

Tested locally, works as expected.
