### PR TITLE
feat(junit-merger): add flag to preserve Python test cases and "is_unity_case" attribute

### DIFF
--- a/pytest-embedded-idf/pytest_embedded_idf/unity_tester.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/unity_tester.py
@@ -787,9 +787,9 @@ class MultiDevRunTestManager:
                     continue
 
                 if k not in output:
-                    output[k] = [f'[dut-{ind}]: {val}']
+                    output[k] = [val]
                 else:
-                    output[k].append(f'[dut-{ind}]: {val}')
+                    output[k].append(val)
 
         for k, val in output.items():
             if k in ('file', 'line'):

--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -43,7 +43,7 @@ from .dut_factory import (
     wokwi_gn,
 )
 from .log import MessageQueue, PexpectProcess
-from .unity import JunitMerger, escape_illegal_xml_chars
+from .unity import JunitMerger, UnityTestReportMode, escape_illegal_xml_chars
 from .utils import (
     SERVICE_LIB_NAMES,
     ClassCliOptions,
@@ -110,6 +110,16 @@ def pytest_addoption(parser):
         '--prettify-junit-report',
         help='y/yes/true for True and n/no/false for False. '
         'Set to True to prettify XML junit report. (Default: False)',
+    )
+    parser.addoption(
+        '--unity-test-report-mode',
+        choices=[UnityTestReportMode.REPLACE.value, UnityTestReportMode.MERGE.value],
+        default=UnityTestReportMode.REPLACE.value,
+        help=(
+            'Specify the behavior for handling Unity test cases in the main JUnit report. '
+            "'merge' includes them alongside the parent Python test case. "
+            "'replace' substitutes the parent Python test case with Unity test cases (default)."
+        ),
     )
 
     # supports parametrization
@@ -1183,7 +1193,9 @@ _junit_report_path_key = pytest.StashKey[str]()
 
 
 def pytest_configure(config: Config) -> None:
-    config.stash[_junit_merger_key] = JunitMerger(config.option.xmlpath)
+    config.stash[_junit_merger_key] = JunitMerger(
+        config.option.xmlpath, config.getoption('unity_test_report_mode', default='replace')
+    )
     config.stash[_junit_report_path_key] = config.option.xmlpath
 
     config.stash[_pytest_embedded_key] = PytestEmbedded(


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->
#### **New Features**
1. **Introduced the `--unity-test-report-mode` Flag**
   - **Behavior**:
     - When enabled, Python test cases are retained in the JUnit report alongside detailed test cases (e.g., C test cases).
     - By default, Python test cases are replaced by detailed test cases in the report.
   - **Purpose**:
     - Helps maintain clarity by allowing both Python and C test cases in the report.

2. **Added the `is_unity_case` Attribute to Test Cases**
   - **Details**:
     - `is_unity_case="1"`: Indicates a Python test case.
     - `is_unity_case="0"`: Indicates a non-Python test case (e.g., C test case).
   - **Impact**:
     - Improves clarity and traceability of test cases in the JUnit report.

---

#### **Bug-fixes**

1. **Fixed Inconsistent `line` and `file` Attributes in XML Reports**
   - Removed `[dut-X]` prefixes from `line` and `file` attributes in the XML report for clarity.
   - **Before**:
     ```xml
     <testcase file="[dut-1]: ./main/case.c" line="[dut-1]: 42" />
     ```
   - **After**:
     ```xml
     <testcase file="./main/case.c" line="42" />
     ```

---

### **Example Usage**

#### **Default Behavior (Without Flag)**
- Python test cases are replaced by detailed test cases.

```xml
<testcase is_unity_case="0" file="./main/case.c" line="42" />
```

- With `--unity-test-report-mode`:

```xml
<testcase is_unity_case="1" classname="test_python" name="test_case_1" />
<testcase is_unity_case="0" file="./main/case.c" line="42" />
```

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

No related issues

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->
### **Environment**
- Tested in a clean virtual environment

1. **Default Behavior** (Without `--unity-test-report-mode`):
   - Verified Python test cases are replaced by detailed test cases.
   - Checked `is_unity_case="0"` for all non-Python test cases.

2. **With `--unity-test-report-mode` Flag**:
   - Ensured Python test cases are retained with `is_unity_case="1"`.
   - Confirmed non-Python test cases have `is_unity_case="0"`.

3. **XML Validation**:
   - Verified proper formatting of `file` and `line` attributes (removed `[dut-X]`).
   - Checked all test cases include the `is_unity_case` attribute.
  
---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
