### PR TITLE
feat: parametrize_wrapper

### DIFF
--- a/docs/usages/markers.rst
+++ b/docs/usages/markers.rst
@@ -61,3 +61,227 @@ Here are examples of how to use ``skip_if_soc`` with different conditions:
    @pytest.mark.parametrize("target", SUPPORTED_TARGETS, indirect=True)
    def test_template():
        pass
+
+*********************
+ ``idf_parametrize``
+*********************
+
+``idf_parametrize`` is a wrapper around ``pytest.mark.parametrize`` that simplifies and extends string-based parameterization for tests. By using ``idf_parametrize``, testing parameters becomes more flexible and easier to maintain.
+
+**Key Features:**
+
+-  **Target Expansion**: Automatically expands lists of supported targets, reducing redundancy in test definitions.
+-  **Markers**: use a marker as one of the parameters. If a marker is used, put it as the last parameter.
+
+Use Cases
+=========
+
+Target Extension
+----------------
+
+In scenarios where the supported targets are [esp32, esp32c3, esp32s3], ``idf_parametrize`` simplifies the process of creating parameterized tests by automatically expanding the target list.
+
+**Example:**
+
+.. code:: python
+
+   @idf_parametrize('target', [
+       ('supported_targets'),
+   ], indirect=True)
+   @idf_parametrize('config', [
+       'default',
+       'psram'
+   ])
+   def test_st(dut: Dut) -> None:
+       ...
+
+**Equivalent to:**
+
+.. code:: python
+
+   @pytest.mark.parametrize('target', [
+       'esp32',
+       'esp32c3',
+       'esp32s3'
+   ], indirect=True)
+   @pytest.mark.parametrize('config', [
+       'default',
+       'psram'
+   ])
+   def test_st(dut: Dut) -> None:
+       ...
+
+**Resulting Parameters Matrix:**
+
+.. list-table::
+   :header-rows: 1
+
+   -  -  Target
+      -  Config
+   -  -  esp32
+      -  default
+   -  -  esp32c3
+      -  default
+   -  -  esp32s3
+      -  default
+   -  -  esp32
+      -  psram
+   -  -  esp32c3
+      -  psram
+   -  -  esp32s3
+      -  psram
+
+Markers
+-------
+
+Markers can also be combined for added flexibility. It must be placed in the last position. In this case, if some test cases do not have markers, you can skip their definition. Look at the example.
+
+**Example:**
+
+In IDF testing, an environment marker (``marker``) determines which test runner will execute a test. This enables tests to run on various runners, such as:
+
+-  **generic**: Tests run on generic runners.
+-  **sdcard**: Tests require an SD card runner.
+-  **usb_device**: Tests require a USB device runner.
+
+.. code:: python
+
+   @pytest.mark.generic
+   @idf_parametrize('config', [
+       'defaults'
+   ], indirect=['config'])
+   @idf_parametrize('target, markers', [
+       ('esp32', (pytest.mark.usb_device,)),
+       ('esp32c3')
+       ('esp32', (pytest.mark.sdcard,))
+   ], indirect=['target'])
+   def test_console(dut: Dut, test_on: str) -> None:
+     ...
+
+**Resulting Parameters Matrix:**
+
+.. list-table::
+   :header-rows: 1
+
+   -  -  Target
+      -  Markers
+   -  -  esp32
+      -  generic, usb_device
+   -  -  esp32c3
+      -  generic, sdcard
+   -  -  esp32
+      -  generic, sdcard
+
+Examples
+========
+
+Target with Config
+------------------
+
+**Example:**
+
+.. code:: python
+
+   @idf_parametrize('target, config', [
+       ('esp32', 'release'),
+       ('esp32c3', 'default'),
+       ('supported_target', 'psram')
+   ], indirect=True)
+   def test_st(dut: Dut) -> None:
+       ...
+
+**Resulting Parameters Matrix:**
+
+.. list-table::
+   :header-rows: 1
+
+   -  -  Target
+      -  Config
+   -  -  esp32
+      -  release
+   -  -  esp32c3
+      -  default
+   -  -  esp32
+      -  psram
+   -  -  esp32c3
+      -  psram
+   -  -  esp32s3
+      -  psram
+
+Supported Target on Runners
+---------------------------
+
+**Example:**
+
+.. code:: python
+
+   @idf_parametrize('target, markers', [
+       ('esp32', (pytest.mark.generic, )),
+       ('esp32c3', (pytest.mark.sdcard, )),
+       ('supported_target', (pytest.mark.usb_device, ))
+   ], indirect=True)
+   def test_st(dut: Dut) -> None:
+       ...
+
+**Resulting Parameters Matrix:**
+
+.. list-table::
+   :header-rows: 1
+
+   -  -  Target
+      -  Markers
+   -  -  esp32
+      -  generic
+   -  -  esp32c3
+      -  sdcard
+   -  -  esp32
+      -  usb_device
+   -  -  esp32c3
+      -  usb_device
+   -  -  esp32s3
+      -  usb_device
+
+Runner for All Tests
+--------------------
+
+**Example:**
+
+.. code:: python
+
+   @pytest.mark.generic
+   @idf_parametrize('target, config', [
+       ('esp32', 'release'),
+       ('esp32c3', 'default'),
+       ('supported_target', 'psram')
+   ], indirect=True)
+   def test_st(dut: Dut) -> None:
+       ...
+
+**Resulting Parameters Matrix:**
+
+.. list-table::
+   :header-rows: 1
+
+   -  -  Target
+      -  Config
+      -  Markers
+
+   -  -  esp32
+      -  release
+      -  generic
+
+   -  -  esp32c3
+      -  default
+      -  generic
+
+   -  -  esp32
+      -  psram
+      -  generic
+
+   -  -  esp32c3
+      -  psram
+      -  generic
+
+   -  -  esp32s3
+      -  psram
+      -  generic

--- a/pytest-embedded-idf/pytest_embedded_idf/unity.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/unity.py
@@ -1,0 +1,80 @@
+import typing as t
+
+import pytest
+from esp_bool_parser import PREVIEW_TARGETS, SUPPORTED_TARGETS
+
+
+def _expand_target_values(values: t.List[t.List[t.Any]], target_index: int) -> t.List[t.List[t.Any]]:
+    """
+    Expands target-specific values into individual test cases.
+    """
+    expanded_values = []
+    for value in values:
+        target = value[target_index]
+        if target == 'supported_targets':
+            expanded_values.extend([
+                value[:target_index] + [target] + value[target_index + 1 :] for target in SUPPORTED_TARGETS
+            ])
+        elif target == 'preview_targets':
+            expanded_values.extend([
+                value[:target_index] + [target] + value[target_index + 1 :] for target in PREVIEW_TARGETS
+            ])
+        else:
+            expanded_values.append(value)
+    return expanded_values
+
+
+def _process_pytest_value(value: t.List[t.Any], runner_index: int) -> t.Union[t.Any, pytest.param]:
+    """
+    Processes a single parameter value, converting it to pytest.param if needed.
+    """
+    if isinstance(value, (int, str)):
+        return value
+
+    params, marks = [], []
+    for i, element in enumerate(value):
+        if i == runner_index:
+            if isinstance(element, str):
+                element = tuple(element.split(','))
+            if isinstance(element, tuple):
+                marks.extend(getattr(pytest.mark, mark) for mark in element)
+        else:
+            params.append(element)
+
+    return pytest.param(*params, marks=marks)
+
+
+def idf_parametrize(
+    param_names: str, values: t.List[t.Union[t.Any, t.Tuple[t.Any, ...]]], indirect: bool = False
+) -> t.Callable[..., None]:
+    """
+    A decorator to unify pytest.mark.parametrize usage in esp-idf.
+
+    Args:
+        param_names (str): Comma-separated parameter names.
+        values (list): List of parameter values. Each value can be a string or a tuple.
+        indirect (bool): If True, marks parameters as indirect.
+
+    Returns:
+        Decorated test function with parametrization applied
+    """
+    param_list = [name.strip() for name in param_names.split(',')]
+    if not param_list:
+        raise ValueError('No parameter names provided')
+
+    runner_index = param_list.index('env_marker') if 'env_marker' in param_list else -1
+    target_index = param_list.index('target') if 'target' in param_list else -1
+
+    filtered_params = [name for name in param_list if name != 'env_marker']
+
+    normalized_values = [[value] if len(param_list) == 1 else list(value) for value in values]
+
+    if target_index != -1:
+        normalized_values = _expand_target_values(normalized_values, target_index)
+
+    processed_values = [_process_pytest_value(value, runner_index) for value in normalized_values]
+
+    def decorator(func):
+        return pytest.mark.parametrize(','.join(filtered_params), processed_values, indirect=indirect)(func)
+
+    return decorator


### PR DESCRIPTION

## Description

Add idf_parametrize decorator to simplify pytest parametrization by handling target expansion and runner marks via string representation.

- Automatically expanding special target values ('supported_targets' and 'preview_targets') into individual test cases;
- Simplifying pytest mark usage by allowing string-based mark definitions instead of direct pytest.mark usage;
- Unifying the parametrization pattern across esp-idf test cases;

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
