### PR TITLE
Feat/improve expecting functions

### DIFF
--- a/docs/usages/expecting.rst
+++ b/docs/usages/expecting.rst
@@ -20,6 +20,10 @@ All of these functions share these possible keyword arguments:
 
    Will raise an exception if the pattern is found in the output, if specified. (Default: None)
 
+-  ``return_what_before_match``
+
+      Will return the bytes read before the match if specified. (Default: False)
+
 *****************************************
  :func:`~pytest_embedded.dut.Dut.expect`
 *****************************************
@@ -129,6 +133,40 @@ What's more, argument ``pattern`` could be a list of all supported types.
            dut.expect(pattern_list)
 
 If you set ``expect_all`` to ``True``, the :func:`~pytest_embedded.dut.Dut.expect` function would return with a list of returned values of each item.
+
+You can also set ``return_what_before_match`` to ``True`` to get the bytes read before the match, instead of the match object.
+
+.. code:: python
+
+   import pexpect
+
+   def test_expect_before_match(dut):
+       dut.write('this would be redirected')
+
+       res = dut.expect('would', return_what_before_match=True)
+       assert res == b'this '
+
+       res = dut.expect_exact('be ', return_what_before_match=True)
+       assert res == b' '
+
+       res = dut.expect('ected', return_what_before_match=True)
+       assert res == b'redir'
+
+.. hint::
+
+   For better performance when retrieving text before a pattern, use:
+
+   .. code:: python
+
+      before_str = dut.expect('pattern', return_what_before_match=True).decode('utf-8')
+
+   Instead of:
+
+   .. code:: python
+
+      before_str = dut.expect('(.+)pattern').group(1).decode('utf-8')
+
+   The latter performs unnecessary recursive matching of preceding bytes.
 
 ***********************************************
  :func:`~pytest_embedded.dut.Dut.expect_exact`

--- a/pytest-embedded/pytest_embedded/dut.py
+++ b/pytest-embedded/pytest_embedded/dut.py
@@ -67,8 +67,17 @@ class Dut(_InjectMixinCls):
     def _pexpect_func(func) -> Callable[..., Union[Match, AnyStr]]:
         @functools.wraps(func)
         def wrapper(
-            self, pattern, *args, expect_all: bool = False, not_matching: List[Union[str, re.Pattern]] = (), **kwargs
+            self,
+            pattern,
+            *args,
+            expect_all: bool = False,
+            not_matching: List[Union[str, re.Pattern]] = (),
+            return_what_before_match: bool = False,
+            **kwargs,
         ) -> Union[Union[Match, AnyStr], List[Union[Match, AnyStr]]]:
+            if return_what_before_match and expect_all:
+                raise ValueError('`return_what_before_match` and `expect_all` cannot be `True` at the same time.')
+
             patterns = to_list(pattern)
             res = []
             while patterns:
@@ -101,6 +110,9 @@ class Dut(_InjectMixinCls):
                 else:
                     break  # one succeeded. leave the loop
 
+            if return_what_before_match:
+                return self.pexpect_proc.before
+
             if len(res) == 1:
                 return res[0]
 
@@ -121,6 +133,8 @@ class Dut(_InjectMixinCls):
             expect_all (bool): need to match all specified patterns if this flag is `True`.
                 Otherwise match any of them could pass
             not_matching: string, or compiled regex, or a list of string and compiled regex.
+            return_what_before_match (bool): return the bytes before the matched pattern.
+                Cannot be specified together with `expect_all`
 
         Returns:
             `AnyStr` or `re.Match`
@@ -143,6 +157,8 @@ class Dut(_InjectMixinCls):
             expect_all (bool): need to match all specified patterns if this flag is `True`.
                 Otherwise match any of them could pass
             not_matching: string, or compiled regex, or a list of string and compiled regex.
+            return_what_before_match (bool): return the bytes before the matched pattern.
+                Cannot be specified together with `expect_all`
 
         Returns:
             `AnyStr` or `re.Match`

--- a/pytest-embedded/pytest_embedded/log.py
+++ b/pytest-embedded/pytest_embedded/log.py
@@ -8,7 +8,6 @@ import tempfile
 import textwrap
 import uuid
 from multiprocessing import queues
-from queue import Empty
 from typing import AnyStr, List, Optional, Union
 
 import pexpect.fdpexpect
@@ -28,7 +27,6 @@ class MessageQueue(queues.Queue):
         if 'ctx' not in kwargs:
             kwargs['ctx'] = _ctx
 
-        self.lock = _ctx.Lock()
         super().__init__(*args, **kwargs)
 
     def put(self, obj, **kwargs):
@@ -44,17 +42,6 @@ class MessageQueue(queues.Queue):
             super().put(_b, **kwargs)
         except:  # noqa # queue might be closed
             pass
-
-    def get_all(self) -> List[bytes]:
-        res = []
-        with self.lock:
-            while True:
-                try:
-                    res.append(self.get_nowait())
-                except Empty:
-                    break
-
-        return res
 
     def write(self, s: AnyStr):
         self.put(s)

--- a/pytest-embedded/tests/test_base.py
+++ b/pytest-embedded/tests/test_base.py
@@ -496,6 +496,28 @@ def test_expect_unity_test_output_multi_dut_with_illegal_chars(testdir):
     assert junit_report[1].find('failure') is not None
 
 
+def test_expect_before_match(testdir):
+    testdir.makepyfile(r"""
+        import pexpect
+
+        def test_expect_before_match(dut):
+            dut.write('this would be redirected')
+
+            res = dut.expect('would', return_what_before_match=True)
+            assert res == b'this '
+
+            res = dut.expect_exact('be ', return_what_before_match=True)
+            assert res == b' '
+
+            res = dut.expect('ected', return_what_before_match=True)
+            assert res == b'redir'
+    """)
+
+    result = testdir.runpytest()
+
+    result.assert_outcomes(passed=1)
+
+
 def test_duplicate_stdout_popen(testdir):
     testdir.makepyfile(r"""
         import pytest


### PR DESCRIPTION
somehow reverting #337 and #334

use `expect(..., return_what_before_match=True)` instead of `expect('(.+)...')` for a better performance.