### PR TITLE
fix(pytest-embedded-qemu): Allowed QEMU RISCV flash image sizes (RDT-1177)

### DIFF
--- a/pytest-embedded-qemu/pytest_embedded_qemu/app.py
+++ b/pytest-embedded-qemu/pytest_embedded_qemu/app.py
@@ -25,16 +25,10 @@ class IdfFlashImageMaker:
     ]
 
     RISCV_FLASH_BIN_SIZES: t.ClassVar[t.List[t.Tuple[int, str]]] = [
-        (256 * 1024, '256KB'),
-        (512 * 1024, '512KB'),
-        (1 * 1024 * 1024, '1MB'),
         (2 * 1024 * 1024, '2MB'),
         (4 * 1024 * 1024, '4MB'),
         (8 * 1024 * 1024, '8MB'),
         (16 * 1024 * 1024, '16MB'),
-        (32 * 1024 * 1024, '32MB'),
-        (64 * 1024 * 1024, '64MB'),
-        (128 * 1024 * 1024, '128MB'),
     ]
 
     def __init__(self, app: 'QemuApp', image_path: str, *, qemu_version: Version = Version('8.0.0')):


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Running a pytest test case using QEMU for ESP32-C3, produces the following error:
```
2025-02-27 20:22:56 INFO Executing qemu-system-riscv32 -nographic -machine esp32c3 -qmp tcp:127.0.0.1:53445,server,wait=off -drive file=/Users/harshal/esp/esp-idf/tools/test_apps/security/secure_boot/test/esp32c3_efuses.bin,if=none,format=raw,id=efuse -global driver=nvram.esp32c3.efuse,property=drive,value=efuse -global driver=timer.esp32c3.timg,property=wdt_disable,value=true -drive file=/Users/harshal/esp/esp-idf/tools/test_apps/security/secure_boot/build/flash_image.bin,if=mtd,format=raw
2025-02-27 20:22:56 esptool.py v4.9.dev5
2025-02-27 20:22:56 SHA digest in image updated
2025-02-27 20:22:56 Wrote 0x80000 bytes to file /Users/harshal/esp/esp-idf/tools/test_apps/security/secure_boot/build/flash_image.bin, ready to flash to offset 0x0
2025-02-27 20:22:56 
2025-02-27 20:22:56 Adding SPI flash device
2025-02-27 20:22:56 qemu-system-riscv32: Drive size error: only 2, 4, 8, and 16MB images are supported
2025-02-27 20:22:56 qemu-system-riscv32: -drive file=/Users/harshal/esp/esp-idf/tools/test_apps/security/secure_boot/build/flash_image.bin,if=mtd,format=raw: machine type does not support if=mtd,bus=0,unit=0
```

ESP32-C3 (riscv) QEMU seems to support only 2, 4, 8, and 16MB flash image sizes [reference](https://github.com/espressif/qemu/blob/esp-develop/hw/riscv/esp32c3.c#L204-L220).

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
