### PR TITLE
feat: get targets filtered by soc attrs

### DIFF
--- a/pytest-embedded-idf/pytest_embedded_idf/utils.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/utils.py
@@ -3,6 +3,7 @@ from contextvars import ContextVar
 
 import pytest
 from esp_bool_parser import PREVIEW_TARGETS, SUPPORTED_TARGETS
+from esp_bool_parser.bool_parser import parse_bool_expr
 
 supported_targets = ContextVar('supported_targets', default=SUPPORTED_TARGETS)
 preview_targets = ContextVar('preview_targets', default=PREVIEW_TARGETS)
@@ -90,3 +91,12 @@ def idf_parametrize(
         return pytest.mark.parametrize(','.join(param_list), processed_values, indirect=indirect)(func)
 
     return decorator
+
+
+def soc_filtered_targets(soc_statement: str) -> t.List[str]:
+    stm = parse_bool_expr(soc_statement)
+    result = []
+    for target in [*supported_targets.get(), *preview_targets.get()]:
+        if stm.get_value(target, ''):
+            result.append(target)
+    return result

--- a/pytest-embedded-idf/tests/test_idf.py
+++ b/pytest-embedded-idf/tests/test_idf.py
@@ -1153,6 +1153,22 @@ def test_skip_if_soc(testdir, copy_mock_esp_idf, monkeypatch):  # noqa: ARG001
         run_test_for_condition(c, cf)
 
 
+def test_soc_filtered_targets(testdir, copy_mock_esp_idf, monkeypatch):  # noqa: ARG001
+    monkeypatch.setenv('IDF_PATH', str(testdir))
+    from pytest_embedded_idf.utils import soc_filtered_targets
+
+    assert soc_filtered_targets('SOC_A == 1') == ['esp32c3', 'esp32s3', 'esp32c6', 'esp32c5']
+    assert soc_filtered_targets('SOC_A == 1 or SOC_B == 1') == [
+        'esp32',
+        'esp32c3',
+        'esp32s3',
+        'esp32c2',
+        'esp32c6',
+        'esp32h2',
+        'esp32c5',
+    ]
+
+
 def test_skip_if_soc_target_in_args(testdir, copy_mock_esp_idf, monkeypatch):  # noqa: ARG001
     monkeypatch.setenv('IDF_PATH', str(testdir))
 


### PR DESCRIPTION

## Description


In this PR, a function is added that will return a target list according to the **SOC_CAPS** attribute. We already have `skip_if_soc`, but in some cases, it is better to directly filter by target rather than adding a skip mark for it.


## Related

## Testing

The `test_soc_filtered_targets` was added.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
