### PR TITLE
feat: use baudrate from EspSerial in EspNuttx (RDT-1275)

### DIFF
--- a/pytest-embedded-nuttx/pytest_embedded_nuttx/serial.py
+++ b/pytest-embedded-nuttx/pytest_embedded_nuttx/serial.py
@@ -16,7 +16,6 @@ class NuttxSerial(EspSerial):
     # Default offset for the primary MCUBoot slot across
     # all Espressif devices on NuttX
     MCUBOOT_PRIMARY_SLOT_OFFSET = 0x10000
-    FLASH_BAUDRATE = 921600
     SERIAL_BAUDRATE = 115200
 
     binary_offsets: ClassVar[Dict[str, int]] = {
@@ -103,7 +102,7 @@ class NuttxSerial(EspSerial):
                 '--port',
                 self.port,
                 '--baud',
-                str(self.FLASH_BAUDRATE),
+                str(self.esptool_baud),
                 'write_flash',
                 *flash_files,
                 *flash_settings,

--- a/pytest-embedded/pytest_embedded/dut_factory.py
+++ b/pytest-embedded/pytest_embedded/dut_factory.py
@@ -243,7 +243,6 @@ def _fixture_classes_and_options_fn(
                     kwargs[fixture].update({
                         'app': None,
                         'baud': int(baud or NuttxSerial.SERIAL_BAUDRATE),
-                        'esptool_baud': int(os.getenv('ESPBAUD') or esptool_baud or NuttxSerial.FLASH_BAUDRATE),
                     })
                 else:
                     from pytest_embedded_serial_esp import EspSerial


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->
This PR modifies the NuttxSerial class.

It had a fixed flash baud rate (for Espressif devices) and now it can be changed through the command line. It simply removes the custom entry for baud rate and uses the baud from the inherited EspSerial class.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Tested by running Pytest without setting `--esptool-baud` and than by setting to a customized value.
The flash is first erased and then the firmware is uploaded. Baud rate line is marked.

- Without setting `esptool-baud`:
```
==========================================
INFO:root:Flashing device
========================================================================================= test session starts =========================================================================================
platform linux -- Python 3.12.3, pytest-8.3.4, pluggy-1.5.0
rootdir: /dev
configfile: null
plugins: html-4.1.1, embedded-1.16.0, metadata-3.1.1
collected 77 items / 76 deselected / 1 selected                                                                                                                                                       
[...]
2025-04-16 14:18:13 Stub running...
2025-04-16 14:18:13 Changing baud rate to 921600  <<<<<=================
2025-04-16 14:18:13 Changed.
2025-04-16 14:18:13 Configuring flash size...
2025-04-16 14:18:13 Flash will be erased from 0x00000000 to 0x0003efff...
2025-04-16 14:18:13 Compressed 255036 bytes to 113121...
Wrote 255036 bytes (113121 compressed) at 0x00000000 in 1.8 seconds (effective 1126.0 kbit/s)...
2025-04-16 14:18:15 Hash of data verified.
2025-04-16 14:18:15 
2025-04-16 14:18:15 Leaving...
2025-04-16 14:18:15 Hard resetting via RTS pin...
[...]
============================================================================ 1 passed, 76 deselected, 3 warnings in 6.08s =============================================================================
```

- Setting `--esptool-baud=460800`:
```
==========================================
INFO:root:Flashing device
========================================================================================= test session starts =========================================================================================
platform linux -- Python 3.12.3, pytest-8.3.4, pluggy-1.5.0
rootdir: /dev
configfile: null
plugins: html-4.1.1, embedded-1.16.0, metadata-3.1.1
collected 77 items / 76 deselected / 1 selected                                                                                                                                                       
[...]
2025-04-16 14:28:26 Stub running...
2025-04-16 14:28:26 Changing baud rate to 460800
2025-04-16 14:28:26 Changed.
2025-04-16 14:28:26 Configuring flash size...
2025-04-16 14:28:26 Flash will be erased from 0x00000000 to 0x0003efff...
2025-04-16 14:28:26 Compressed 255036 bytes to 113121...
Wrote 255036 bytes (113121 compressed) at 0x00000000 in 2.6 seconds (effective 772.6 kbit/s)...
2025-04-16 14:28:29 Hash of data verified.
2025-04-16 14:28:29 
2025-04-16 14:28:29 Leaving...
2025-04-16 14:28:29 Hard resetting via RTS pin...
[...]
============================================================================ 1 passed, 76 deselected, 3 warnings in 6.98s =============================================================================
```

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
