### PR TITLE
fix: flash mode exception on Nuttx (RDT-1276)

### DIFF
--- a/pytest-embedded-nuttx/pytest_embedded_nuttx/serial.py
+++ b/pytest-embedded-nuttx/pytest_embedded_nuttx/serial.py
@@ -76,6 +76,12 @@ class NuttxSerial(EspSerial):
         # Flash Mode
         self.flash_mode = get_key_from_value(FLASH_MODES, image.flash_mode)
 
+        # From esp-idf/components/esptool_py:
+        # We use esptool.py to flash bootloader in dio mode for QIO/QOUT, bootloader then
+        # upgrades itself to quad mode during initialization.
+        if self.flash_mode in ("qio", "qout"):
+            self.flash_mode = "dio"
+
     @EspSerial.use_esptool()
     def flash(self) -> None:
         """Flash the binary files to the board."""

--- a/pytest-embedded-nuttx/pytest_embedded_nuttx/serial.py
+++ b/pytest-embedded-nuttx/pytest_embedded_nuttx/serial.py
@@ -79,8 +79,8 @@ class NuttxSerial(EspSerial):
         # From esp-idf/components/esptool_py:
         # We use esptool.py to flash bootloader in dio mode for QIO/QOUT, bootloader then
         # upgrades itself to quad mode during initialization.
-        if self.flash_mode in ("qio", "qout"):
-            self.flash_mode = "dio"
+        if self.flash_mode in ('qio', 'qout'):
+            self.flash_mode = 'dio'
 
     @EspSerial.use_esptool()
     def flash(self) -> None:


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

This PR adds an exception for flash mode when in QIO/QOUT mode, defaulting to DIO.

It follows the following description on ESP-IDF, which can be found [here](https://github.com/espressif/esp-idf/blob/194ea85ee82e65ec1b9236225425540a61754201/components/esptool_py/Kconfig.projbuild#L79):
```
# Note: we use esptool.py to flash bootloader in
# dio mode for QIO/QOUT, bootloader then upgrades
# itself to quad mode during initialisation
```

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing
Before this fix, the device enters a boot loop after flashing:

```
2025-04-16 15:47:58 Hard resetting via RTS pin...
INFO:root:Resetting board
Hard resetting via RTS pin...
2025-04-16 15:47:58 ESP-ROM:esp32h2-ESP-ROM:esp32h2-20221101
2025-04-16 15:47:58 Build:Nov  1 2022
2025-04-16 15:47:58 rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
2025-04-16 15:47:58 SPIWP:0xee
2025-04-16 15:47:58 mode:QOUT, clock div:1
2025-04-16 15:47:58 load:0x40800000,len:0x5354
2025-04-16 15:47:58 ets_loader.c 64 
2025-04-16 15:47:59 ESP-ROM:esp32h2-20221101
2025-04-16 15:47:59 Build:Nov  1 2022
2025-04-16 15:47:59 rst:0x7 (TG0_WDT_HPSYS),boot:0xc (SPI_FAST_FLASH_BOOT)
2025-04-16 15:47:59 Saved PC:0x400042a8
2025-04-16 15:47:59 SPIWP:0xee
2025-04-16 15:47:59 mode:QOUT, clock div:1
2025-04-16 15:47:59 load:0x40800000,len:0x5354
2025-04-16 15:47:59 ets_loader.c 64 
2025-04-16 15:47:59 ESP-ROM:esp32h2-20221101
2025-04-16 15:47:59 Build:Nov  1 2022
[...]
```

After the fix it boots properly:
```
2025-04-16 15:48:16 Configuring flash size...
2025-04-16 15:48:16 Flash will be erased from 0x00000000 to 0x00039fff...
2025-04-16 15:48:16 Flash params set to 0x022f
2025-04-16 15:48:16 Compressed 236768 bytes to 99417...
Wrote 236768 bytes (99417 compressed) at 0x00000000 in 2.0 seconds (effective 936.7 kbit/s)...
2025-04-16 15:48:18 Hash of data verified.
2025-04-16 15:48:18 
2025-04-16 15:48:18 Leaving...
2025-04-16 15:48:18 Hard resetting via RTS pin...
INFO:root:Resetting board
Hard resetting via RTS pin...
2025-04-16 15:48:19 ESP-ROM:eESP-ROM:esp32h2-20221101
2025-04-16 15:48:19 Build:Nov  1 2022
2025-04-16 15:48:19 rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
2025-04-16 15:48:19 SPIWP:0xee
2025-04-16 15:48:19 mode:DIO, clock div:1
2025-04-16 15:48:19 load:0x40800000,len:0x5354
2025-04-16 15:48:19 load:0x40805360,len:0x1464
2025-04-16 15:48:19 SHA-256 comparison failed:
2025-04-16 15:48:19 Calculated: 2fd807a61a0b628aa7fa8b94f940bc385831299af192c086d24e493a4e66338c
2025-04-16 15:48:19 Expected: 0000000000980000000000000000000000000000000000000000000000000000
2025-04-16 15:48:19 Attempting to boot anyway...
2025-04-16 15:48:19 entry 0x40804ffa
2025-04-16 15:48:19 pmu_param(dbg): blk_version is less than 3, act dbias not burnt in efuse
2025-04-16 15:48:19 pmu_param(dbg): blk_version is less than 3, act dbias not burnt in efuse
2025-04-16 15:48:19 *** Booting NuttX ***
2025-04-16 15:48:19 D (54) bootloader_flash: non-XMC chip detected by SFDP Read (FF), skip.
2025-04-16 15:48:19 D (54) bootloader_flash: mmu set block paddr=0x00000000 (was 0xffffffff)
2025-04-16 15:48:19 I (56) boot: chip revision: v0.0
2025-04-16 15:48:19 D (59) boot.esp32h2: magic e9
2025-04-16 15:48:19 D (62) boot.esp32h2: segments 02
2025-04-16 15:48:19 D (65) boot.esp32h2: spi_mode 02
2025-04-16 15:48:19 D (68) boot.esp32h2: spi_speed 0f
2025-04-16 15:48:19 D (71) boot.esp32h2: spi_size 02
2025-04-16 15:48:19 I (74) boot.esp32h2: SPI Speed      : 64MHz
2025-04-16 15:48:19 I (78) boot.esp32h2: SPI Mode       : DIO
2025-04-16 15:48:19 I (82) boot.esp32h2: SPI Flash Size : 4MB
2025-04-16 15:48:19 I (85) boot: Enabling RNG early entropy source...
2025-04-16 15:48:19 dram: lma 0x00000020 vma 0x40800000 len 0x5354   (21332)
2025-04-16 15:48:19 dram: lma 0x0000537c vma 0x40805360 len 0x1464   (5220)
2025-04-16 15:48:19 padd: lma 0x000067f8 vma 0x00000000 len 0x9800   (38912)
2025-04-16 15:48:19 imap: lma 0x00010000 vma 0x42020000 len 0x5584   (21892)
2025-04-16 15:48:19 D (110) bootloader_flash: mmu set block paddr=0x00010000 (was 0x00000000)
2025-04-16 15:48:19 padd: lma 0x0001558c vma 0x00000000 len 0xaa6c   (43628)
2025-04-16 15:48:19 imap: lma 0x00020000 vma 0x42000000 len 0x19ce0  (105696)
2025-04-16 15:48:19 total segments stored 6
2025-04-16 15:48:19 pmu_param(dbg): blk_version is less than 3, act dbias not burnt in efuse
2025-04-16 15:48:19 pmu_param(dbg): blk_version is less than 3, act dbias not burnt in efuse
2025-04-16 15:48:19 pmu_param(dbg): blk_version is less than 3, act dbias not burnt in efuse
2025-04-16 15:48:19 D (156) clk: RTC_SLOW_CLK calibration value: 3281616
2025-04-16 15:48:19 W (164
2025-04-16 15:48:19 
2025-04-16 15:48:19 NuttShell (NSH) NuttX-10.4.0
2025-04-16 15:48:19 nsh> INFO:root:Flashing process finalized
```


<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
