### PR TITLE
fix: synced cache file by adding support for filelock

### DIFF
--- a/pytest-embedded/pyproject.toml
+++ b/pytest-embedded/pyproject.toml
@@ -31,6 +31,7 @@ requires-python = ">=3.7"
 dependencies = [
     "pytest>=7.0",
     "pexpect>=4.4",
+    "filelock>=3.12.2"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description

We had an issue with a cache file race condition while running pytest-xdist. One possible solution is to add filelock, which ensures synchronized access.

## Related

Fixed #354

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
