### PR TITLE
fix: support testing without flasher_args.json (CII-159)

### DIFF
--- a/pytest-embedded-idf/pytest_embedded_idf/app.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/app.py
@@ -24,6 +24,9 @@ class IdfApp(App):
         flash_args (dict[str, Any]): dict of flasher_args.json
         flash_files (list[FlashFile]): list of (offset, file path, encrypted) of files need to be flashed in
         flash_settings (dict[str, Any]): dict of flash settings
+        is_loadable_elf (bool): Chip RAM app (``APP_BUILD_TYPE_RAM`` / ``APP_BUILD_TYPE_ELF_RAM``); esptool
+            ``load_ram`` path.
+        is_linux_elf (bool): Linux host ELF-only build (``APP_BUILD_TYPE_ELF_ONLY``), no flasher_args.json.
     """
 
     XTENSA_TARGETS: ClassVar[list[str]] = ['esp32', 'esp32s2', 'esp32s3']
@@ -74,10 +77,13 @@ class IdfApp(App):
         else:
             self.is_loadable_elf = False
 
+        # Linux target: ELF-only output, no flasher_args.json.
+        self.is_linux_elf = bool(self.sdkconfig.get('APP_BUILD_TYPE_ELF_ONLY'))
+
         self.bin_file = self._get_bin_file()
         self.flash_args, self.flash_files, self.flash_settings = {}, [], {}
 
-        if not self.is_loadable_elf:
+        if not (self.is_loadable_elf or self.is_linux_elf):
             self.flash_args, self.flash_files, self.flash_settings = self._parse_flash_args_json()
 
     @property
@@ -153,10 +159,15 @@ class IdfApp(App):
         if self._partition_table is not None:
             return self._partition_table
 
-        partition_file = os.path.join(
-            self.binary_path,
-            self.flash_args.get('partition_table', self.flash_args.get('partition-table', {})).get('file', ''),
+        # see - vs _ in 'partition table' key name
+        partition_rel_path = self.flash_args.get('partition_table', self.flash_args.get('partition-table', {})).get(
+            'file', ''
         )
+        if not partition_rel_path:
+            self._partition_table = {}
+            return self._partition_table
+
+        partition_file = os.path.join(self.binary_path, partition_rel_path)
         process = subprocess.Popen(
             [sys.executable, self.parttool_path, partition_file],
             stdout=subprocess.PIPE,

--- a/pytest-embedded-idf/pytest_embedded_idf/dut.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/dut.py
@@ -270,6 +270,11 @@ class IdfDut(IdfUnityDutMixin, SerialDut):
             # >>> self.gdb.write('load')
             return
 
+        if self.app.is_linux_elf:
+            # linux ELF file. OpenOCD is meaningless
+            logging.debug('Linux ELF-only build; skipping OpenOCD program_esp.')
+            return
+
         for _f in self.app.flash_files:
             if _f.encrypted:
                 raise ValueError("Encrypted files can't be flashed in via JTAG")

--- a/pytest-embedded-idf/pytest_embedded_idf/serial.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/serial.py
@@ -72,6 +72,10 @@ class IdfSerial(EspSerial):
         else:
             if self.app.is_loadable_elf:
                 self.load_ram()
+            elif self.app.is_linux_elf:
+                # Host Linux ELF (IDF_TARGET_LINUX); no flasher_args.json.
+                logging.info('Linux ELF-only build; skipping auto flash.')
+                super()._start()
             else:
                 self.flash()
 


### PR DESCRIPTION
## Description

This allows testing build where only the ELF file is generated without flashable binaries. This can be the case e.g. for linux builds.

## Related

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
