### PR TITLE
fix(serial): during auto-reconnect, update all pySerial references (CII-181)

### DIFF
--- a/pytest-embedded-serial/pytest_embedded_serial/serial.py
+++ b/pytest-embedded-serial/pytest_embedded_serial/serial.py
@@ -108,7 +108,7 @@ class Serial:
 
         # Here the reason why we're still using thread is,
         # the `pyserial` object can't be pickled when using multiprocessing.Process
-        self._redirect_thread = _SerialRedirectThread(self._q, self.proc)
+        self._redirect_thread = _SerialRedirectThread(self._q, self)
         self._redirect_thread.start()
 
     def stop_redirect_thread(self) -> bool:
@@ -168,7 +168,7 @@ class _SerialRedirectThread(threading.Thread):
     Redirect serial thread
     """
 
-    def __init__(self, msg_queue: MessageQueue, s: pyserial.Serial):
+    def __init__(self, msg_queue: MessageQueue, s: Serial):
         self._q = msg_queue
         self._event_q = multiprocessing.Queue()
         self._s = s
@@ -196,22 +196,22 @@ class _SerialRedirectThread(threading.Thread):
                     continue
 
                 try:
-                    s = self._s.read_all()
+                    s = self._s.proc.read_all()
                 except OSError as e:
                     logging.error(f'OSError detected: {e}. Serial connection may be lost.')
-                    if self._s.closed:
+                    if self._s.proc.closed:
                         logging.error('Serial port is already closed. Exiting event loop.')
                         return
 
-                    port = self._s.port
+                    port = self._s.proc.port
                     port_config = {
-                        'baudrate': self._s.baudrate,
-                        'bytesize': self._s.bytesize,
-                        'parity': self._s.parity,
-                        'stopbits': self._s.stopbits,
-                        'timeout': self._s.timeout,
-                        'xonxoff': self._s.xonxoff,
-                        'rtscts': self._s.rtscts,
+                        'baudrate': self._s.proc.baudrate,
+                        'bytesize': self._s.proc.bytesize,
+                        'parity': self._s.proc.parity,
+                        'stopbits': self._s.proc.stopbits,
+                        'timeout': self._s.proc.timeout,
+                        'xonxoff': self._s.proc.xonxoff,
+                        'rtscts': self._s.proc.rtscts,
                     }
                     for attempt in range(1, 4):
                         delay = attempt * 1.5
@@ -220,8 +220,8 @@ class _SerialRedirectThread(threading.Thread):
                         )
                         time.sleep(delay)
                         try:
-                            self._s.close()
-                            self._s = pyserial.serial_for_url(port, **port_config)
+                            self._s.proc.close()
+                            self._s.proc = pyserial.serial_for_url(port, **port_config)
                             logging.info(f'Successfully reconnected to serial port {port}.')
                             break
                         except Exception as e:


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

The previous implementation of the auto-reconnection feature (commit 019e38a97d9d0be88569c50bd1426191a6f69010) detects connection loss in the reader _event_loop() and proceeds to re-assign the local variable to a fresh pySerial instance. However, the `proc` member of the Serial class is not updated, and attempts to write to the Serial instance continue to fail even after the reconnection logic succeeded.

Therefore, make _SerialRedirectThread take the Serial instance as argument, instead of the pySerial.Serial object.
The _event_loop() can thus operate on and update the `proc` member directly.

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

Tested locally with an Espressif DevKit, manually disconnecting & reconnecting the serial line
<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
