### PR TITLE
feat: added env for setup test case default timeout

### DIFF
--- a/pytest-embedded-idf/pytest_embedded_idf/unity_tester.py
+++ b/pytest-embedded-idf/pytest_embedded_idf/unity_tester.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 import logging
+import os
 import re
 import time
 import typing as t
@@ -24,7 +25,7 @@ if t.TYPE_CHECKING:
     from .dut import IdfDut
 
 DEFAULT_START_RETRY = 3
-DEFAULT_TIMEOUT = 90
+DEFAULT_TIMEOUT = os.getenv('TEST_CASE_DEFAULT_TIMEOUT', 90)
 WAIT_FOR_MENU_TIMEOUT = 10
 
 READY_PATTERN_LIST = [


### PR DESCRIPTION
## Description

Actually, 90 seconds is quite a long timeout per test case, and when a test case starts failing, it's usually due to a timeout. So in most cases, the timeout should be around 10–20 seconds, and for some of them, we can explicitly set a higher timeout.

