### PR TITLE
fix: read the redirect log as bytes, not text (CII-240)

### DIFF
--- a/pytest-embedded/pytest_embedded/log.py
+++ b/pytest-embedded/pytest_embedded/log.py
@@ -154,7 +154,13 @@ class _PopenRedirectProcess(_ctx.Process):
 
     @staticmethod
     def _forward_io(msg_queue, logfile) -> None:
-        with open(logfile) as fr:
+        # Binary, because the file is still being written to: a text-mode read finalizes the
+        # decoder at every temporary EOF, and a UTF-8 sequence straddling that boundary raises
+        # UnicodeDecodeError. `except Exception` below would swallow it and this process would
+        # exit 0, cutting the output off for the rest of the session. Decoding here is not
+        # needed either - `MessageQueue.put` re-encodes with `to_bytes`, the pexpect buffer is
+        # bytes, and the serial transport already forwards `read_all()` undecoded.
+        with open(logfile, 'rb') as fr:
             while True:
                 try:
                     msg_queue.put(fr.read())  # msg_queue may be closed

--- a/pytest-embedded/tests/test_base.py
+++ b/pytest-embedded/tests/test_base.py
@@ -1010,3 +1010,84 @@ def test_multi_dut_no_data_loss(testdir):
 
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
+
+
+def _drain(q, deadline_s=10):
+    """Collect everything the queue yields until it stays quiet for a moment."""
+    import queue as _q
+    import time
+
+    chunks = []
+    deadline = time.monotonic() + deadline_s
+    while time.monotonic() < deadline:
+        try:
+            chunks.append(q.get(timeout=0.2))
+        except _q.Empty:
+            if chunks:
+                break
+    return b''.join(chunks)
+
+
+def test_forward_io_survives_split_multibyte_char(tmp_path):
+    """A multi-byte sequence split across two appends must not kill the forwarder.
+
+    The redirect log is written to while it is being read, so the reader keeps hitting a
+    temporary EOF. Decoding there turns any UTF-8 sequence straddling that boundary into
+    a UnicodeDecodeError, which the forwarder's `except Exception` swallows: the process
+    exits 0 and DUT output stops for the rest of the session.
+    """
+    import time
+
+    from pytest_embedded.log import MessageQueue, _PopenRedirectProcess
+
+    logfile = str(tmp_path / 'redirect.log')
+    open(logfile, 'wb').close()
+
+    q = MessageQueue()
+    p = _PopenRedirectProcess(q, logfile)
+    p.start()
+    try:
+        with open(logfile, 'ab') as fw:
+            fw.write(b'head\n')
+            fw.flush()
+        assert b'head\n' in _drain(q), 'nothing forwarded before the split'
+
+        # U+2014 EM DASH, torn in half: the reader reaches EOF between the two bytes.
+        with open(logfile, 'ab') as fw:
+            fw.write(b'dash \xe2')
+            fw.flush()
+        time.sleep(0.5)
+        assert p.is_alive(), f'forwarder died on a split sequence (exitcode={p.exitcode})'
+
+        with open(logfile, 'ab') as fw:
+            fw.write(b'\x80\x94 tail\n')
+            fw.flush()
+        assert b'dash \xe2\x80\x94 tail\n' in _drain(q), 'the split character was not reassembled'
+    finally:
+        p.terminate()
+        p.join(timeout=5)
+
+
+def test_forward_io_preserves_carriage_returns(tmp_path):
+    """The forwarder passes the log through byte for byte, CR included.
+
+    Reading in text mode used to apply universal-newline translation, so a device sending
+    CRLF was forwarded as LF. The serial transport never did that, and the console writer
+    and the Unity parser both handle CRLF themselves.
+    """
+    from pytest_embedded.log import MessageQueue, _PopenRedirectProcess
+
+    logfile = str(tmp_path / 'redirect.log')
+    open(logfile, 'wb').close()
+
+    q = MessageQueue()
+    p = _PopenRedirectProcess(q, logfile)
+    p.start()
+    try:
+        with open(logfile, 'ab') as fw:
+            fw.write(b'first\r\nsecond\r\n')
+            fw.flush()
+        assert _drain(q) == b'first\r\nsecond\r\n'
+    finally:
+        p.terminate()
+        p.join(timeout=5)


### PR DESCRIPTION
Fixes #425.

`_PopenRedirectProcess._forward_io` read the redirect log in text mode while it was still
being appended to. Every read reaches a temporary EOF, which finalizes the incremental
decoder, so a UTF-8 sequence straddling that boundary raises `UnicodeDecodeError`. The
surrounding `except Exception` swallows it — the process exits 0 with an empty stderr and
DUT output stops for the rest of the session, surfacing later as a pexpect timeout that
names no cause.

## Why binary rather than a decoder

The decode was never needed here:

- `MessageQueue.put` accepts `str | bytes` and re-encodes through `to_bytes()`, which is
  the identity for bytes;
- `PexpectProcess`'s buffer is bytes;
- the serial transport already forwards `read_all()` undecoded
  (`pytest-embedded-serial/pytest_embedded_serial/serial.py:244`).

So today's path is a bytes → str → bytes round trip. Reading in binary removes the failure
mode and makes the two transports consistent.

## One behaviour change

Text mode applied universal-newline translation, so a DUT sending CRLF was forwarded as LF.
Binary mode preserves CR — which is what the serial transport already delivers, and both
`_listen` and the Unity parser handle CRLF already. `test_forward_io_preserves_carriage_returns`
pins it so it stays deliberate.

## Tests

Two unit tests next to the existing `test_listen_no_data_loss_*`, in the same shape.

The reproduction condition is worth noting: the multi-byte sequence has to be split
**between two appends**, which a byte-at-a-time UART/QEMU stream does naturally. Writing a
whole line in a single `write()` does not reproduce it.

On unmodified `main` both fail:

```
AssertionError: forwarder died on a split sequence (exitcode=0)
AssertionError: assert b'first\nsecond\n' == b'first\r\nsecond\r\n'
```

With this change both pass.

## Test runs on this machine

- `pytest-embedded/tests/` — 36 passed, 1 skipped, 2 failed.
- The other eight packages — 47 failed, 24 passed, 9 skipped.

All of those failures reproduce on unmodified `main`: I ran the same selection on both refs
and the sorted `FAILED` lists are identical (empty `diff`), with the same 47/24/9 totals.
They need QEMU binaries, serial ports, an Arduino CLI or NuttX images, none of which are
present here. `test_temp_disable_packages` fails for a separate reason — it expects
`ImportError` for the sibling packages, which the editable install from CONTRIBUTING makes
importable.

## Not included

Narrowing `except Exception`. `MessageQueue.put` already swallows a closed queue itself, and
the only escape I observed at teardown was `BrokenPipeError`, but I have not shown that list
to be exhaustive — so this PR stays one change. Happy to add it here if you would rather have
it together.
