### PR TITLE
fix: expose `target` on the emulator duts (CII-248)

### DIFF
--- a/pytest-embedded-espemu/pytest_embedded_espemu/dut.py
+++ b/pytest-embedded-espemu/pytest_embedded_espemu/dut.py
@@ -8,6 +8,9 @@ from .espemu import EspEmu
 class EspEmuDut(Dut):
     """
     esp-emu dut class
+
+    Attributes:
+        target (str): target chip type, taken from the app
     """
 
     def __init__(
@@ -18,6 +21,11 @@ class EspEmuDut(Dut):
         self.espemu = espemu
 
         super().__init__(**kwargs)
+
+        # `IdfDut` exposes this for serial runs, and test fixtures use it to
+        # select target specific behavior. `EspEmuApp` is an `IdfApp`, so the
+        # target is known here as well; keep it optional for other app classes.
+        self.target: str | None = getattr(self.app, 'target', None)
 
         self._hard_reset_func = self.espemu._hard_reset
 

--- a/pytest-embedded-qemu/pytest_embedded_qemu/dut.py
+++ b/pytest-embedded-qemu/pytest_embedded_qemu/dut.py
@@ -8,6 +8,9 @@ from .qemu import Qemu
 class QemuDut(Dut):
     """
     QEMU dut class
+
+    Attributes:
+        target (str): target chip type, taken from the app
     """
 
     def __init__(
@@ -18,6 +21,11 @@ class QemuDut(Dut):
         self.qemu = qemu
 
         super().__init__(**kwargs)
+
+        # `IdfDut` exposes this for serial runs, and test fixtures use it to
+        # select target specific behavior. `QemuApp` is an `IdfApp`, so the
+        # target is known here as well; keep it optional for other app classes.
+        self.target: str | None = getattr(self.app, 'target', None)
 
         self._hard_reset_func = self.qemu._hard_reset
 


### PR DESCRIPTION
## Description

Any test or fixture that selects behavior by target fails under `--embedded-services idf,espemu` or `--embedded-services idf,qemu`:
```
AttributeError: 'EspEmuDutWithIdfUnityDutMixin' object has no attribute 'target'
AttributeError: 'QemuDutWithIdfUnityDutMixin'   object has no attribute 'target'
```

`EspEmuDut` and `QemuDut` both extend the plain `Dut`, which knows `self.app` but not the target. The attribute is set by `IdfDut.__init__` (`self.target = app.target`), and `IdfDut(IdfUnityDutMixin, SerialDut)` is serial based, so `dut_factory.py` correctly picks the emulator dut classes and the attribute is simply absent.

This is not a corner case for ESP-IDF users: `dut.target` is referenced by ESP-IDF's root `conftest.py` helpers, so a large share of ESP-IDF's test cases cannot run under either emulator. Reproduced with `examples/get-started/hello_world` on esp32c3 for both services:

```
$ pytest examples/get-started/hello_world -k test_hello_world
          --target esp32c3 --embedded-services idf,qemu
...
conftest.py:508: in real_func
    dut.target,
E   AttributeError: 'QemuDutWithIdfUnityDutMixin' object has no attribute 'target'
```

### Fix

Take the target from the app in both duts. `EspEmuApp` and `QemuApp` are `IdfApp` subclasses, so the value is available; `getattr` keeps it optional for other app classes, since the base `App` has no `target`.

```python
self.target: str | None = getattr(self.app, 'target', None)
```

NuttxQemuDut inherits QemuDut and picks this up too, with None for apps that have no target.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
