### PR TITLE
fix: let the `unity_tester` fixture accept emulator duts (CII-249)

### DIFF
--- a/pytest-embedded/pytest_embedded/plugin.py
+++ b/pytest-embedded/pytest_embedded/plugin.py
@@ -1349,16 +1349,19 @@ def dut(
 @pytest.fixture
 def unity_tester(dut: t.Union['IdfDut', tuple['IdfDut']]) -> t.Optional['CaseTester']:
     try:
-        from pytest_embedded_idf import CaseTester, IdfDut
+        from pytest_embedded_idf import CaseTester
+        from pytest_embedded_idf.unity_tester import IdfUnityDutMixin
     except ImportError:
         yield None
     else:
-        # all dut instance must be IdfDut to use this fixture
-        for _dut in to_list(dut):
-            if not isinstance(_dut, IdfDut):
-                yield None
-
-        yield CaseTester(to_list(dut))
+        duts = to_list(dut)
+        # `CaseTester` drives the unity test menu, which every dut carrying
+        # `IdfUnityDutMixin` provides: `IdfDut` inherits it, and the dut factory
+        # mixes it into the qemu and esp-emu duts when the idf service is used.
+        if all(isinstance(_dut, IdfUnityDutMixin) for _dut in duts):
+            yield CaseTester(duts)
+        else:
+            yield None
 
 
 ##################

--- a/pytest-embedded/tests/test_base.py
+++ b/pytest-embedded/tests/test_base.py
@@ -334,20 +334,27 @@ def test_expect(testdir):
 def test_expect_from_timeout(testdir):
     testdir.makepyfile(r"""
         import threading
-        import time
         import pexpect
 
         def test_expect_from_timeout(msg_queue, dut):
+            stop = threading.Event()
+
             def write_bytes():
                 for _ in range(5):
+                    if stop.is_set():
+                        return
                     msg_queue.write('1')
-                    time.sleep(1.5)
+                    stop.wait(1.5)
 
             write_thread = threading.Thread(target=write_bytes, daemon=True)
             write_thread.start()
 
-            res = dut.expect(pexpect.TIMEOUT, timeout=4)
-            assert res == b'111'
+            try:
+                res = dut.expect(pexpect.TIMEOUT, timeout=4)
+                assert res == b'111'
+            finally:
+                stop.set()
+                write_thread.join(timeout=2)
     """)
 
     result = testdir.runpytest('-s')


### PR DESCRIPTION
## Description

Every test using the `unity_tester` fixture errors out under `--embedded-services idf,espemu` or `--embedded-services idf,qemu`:

```
E   Failed: fixture function has more than one 'yield':

except ImportError:
    yield None
        yield None                                                                                 
    yield CaseTester(to_list(dut))
```
  Two separate bugs in the same fixture:

1. **Double yield.** `yield None` sits inside the `for` loop, so it does not end the generator, execution continues to `yield CaseTester()` and pytest rejects the fixture.
2. **The gate is incorrect.** `isinstance(_dut, IdfDut)` can never hold for an emulator dut: `IdfDut(IdfUnityDutMixin, SerialDut)` is serial based, so `dut_factory.py` picks `EspEmuDut` / `QemuDut` instead. But the factory deliberately mixes `IdfUnityDutMixin` into those duts when the `idf` service  is used (`dut_factory.py:393`), and that mixin is all `CaseTester` needs, it drives `dut.test_menu`, not anything serial specific.

Because ESP-IDF's root `conftest.py` wraps this fixture:

```python
@pytest.fixture
def case_tester(unity_tester: CaseTester) -> CaseTester:
     return unity_tester
```

so every ESP-IDF test taking `case_tester` is unrunnable on either emulator.

## Fix
  
Yield exactly once per path, and accept any dut that carries the mixing CaseTester relies on:

```
duts = to_list(dut)
if all(isinstance(_dut, IdfUnityDutMixin) for _dut in duts):
    yield CaseTester(duts)
else:                                                                                                      
    yield None
```

- `IdfDut` still satisfies the check, since it inherits `IdfUnityDutMixin`, thus, no change for serial runs.
- Applies equally to the qemu service; nothing qemu specific is needed.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
